### PR TITLE
Add index.php to link in table

### DIFF
--- a/xhprof_lib/templates/profTable.phtml
+++ b/xhprof_lib/templates/profTable.phtml
@@ -19,7 +19,7 @@
     {?>
     
     <tr>
-        <td><a href="?run=<?php echo $run1; ?>&amp;symbol=<?php echo urlencode($element['fn']); ?>"><?php echo htmlentities($element['fn'], ENT_QUOTES, 'UTF-8'); ?></a></td>
+        <td><a href="index.php?run=<?php echo $run1; ?>&amp;symbol=<?php echo urlencode($element['fn']); ?>"><?php echo htmlentities($element['fn'], ENT_QUOTES, 'UTF-8'); ?></a></td>
         <td><?php echo $element['ct']; ?></td>
         <td><?php echo $element['wt']; ?></td>
         <td><?php echo $element['cpu']; ?></td>


### PR DESCRIPTION
Ran into some issues with links not working due to index.php not being explicitly specified. Added it to fix this.
