### PR TITLE
Allow XHProf to run on xhgui

### DIFF
--- a/xhprof_html/callgraph.php
+++ b/xhprof_html/callgraph.php
@@ -28,7 +28,7 @@
  *
  * @author Changhao Jiang (cjiang@facebook.com)
  */
-require ("../xhprof_lib/config.php");
+require_once ("../xhprof_lib/config.php");
 
 if (!in_array($_SERVER['REMOTE_ADDR'], $controlIPs))
 {

--- a/xhprof_html/index.php
+++ b/xhprof_html/index.php
@@ -2,7 +2,7 @@
 if (!defined('XHPROF_LIB_ROOT')) {
   define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
 }
-require (XHPROF_LIB_ROOT . "/config.php");
+require_once (XHPROF_LIB_ROOT . "/config.php");
 include_once XHPROF_LIB_ROOT . '/display/xhprof.php';
 include (XHPROF_LIB_ROOT . "/utils/common.php");
 


### PR DESCRIPTION
Basic change to require_once instead of require. Let's the same header.php and footer.php be used, even on the actual xhgui site.
