### PR TITLE
Make the usage of php_admin_value auto_append_file unnecessary

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -108,3 +108,10 @@ if (extension_loaded('xhprof') && $_xhprof['doprofile'] === true) {
     $message = 'Warning! Unable to profile run, xhprof extension not loaded';
     trigger_error($message, E_WARNING);
 }
+
+function xhprof_shutdown_function() {
+    global $_xhprof;
+    require dirname(__FILE__).'/footer.php';
+}
+
+register_shutdown_function('xhprof_shutdown_function');


### PR DESCRIPTION
When calling exit somewhere in your code the auto_append_file will never be included.
Using register_shutdown_function circumvents this problem and also removes the required php ini setting.
