### PR TITLE
Fixed Warning.

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -108,7 +108,7 @@ if (extension_loaded('xhprof') && $_xhprof['doprofile'] === true) {
 }elseif(!extension_loaded('xhprof') && $_xhprof['display'] === true)
 {
     $message = 'Warning! Unable to profile run, xhprof extension not loaded';
-    trigger_error($message, E_WARNING);
+    trigger_error($message, E_USER_WARNING);
 }
 
 function xhprof_shutdown_function() {


### PR DESCRIPTION
trigger_error() expects second parameter to be E_USER family of constants. So E_WARNING becomes E_USER_WARNING

See: http://php.net/manual/en/function.trigger-error.php
