### PR TITLE
E_STRICT strict runtime notice error

### DIFF
--- a/xhprof_lib/utils/Db/Abstract.php
+++ b/xhprof_lib/utils/Db/Abstract.php
@@ -11,11 +11,23 @@ abstract class Db_Abstract
     
     abstract public function connect();
     abstract public function query($sql);
-    abstract public static function getNextAssoc($resultSet);
     abstract public function escape($str);
     abstract public function affectedRows();
-    abstract public static function unixTimestamp($field);
-    abstract public static function dateSub($days);
+
+    public static function unixTimestamp($field)
+    {
+        throw new RuntimeException("Method '".get_called_class()."::".__FUNCTION__."' not implemented");
+    }
+
+    public static function dateSub($days)
+    {
+        throw new RuntimeException("Method '".get_called_class()."::".__FUNCTION__."' not implemented");
+    }
+
+    public static function getNextAssoc($resultSet)
+    {
+        throw new RuntimeException("Method '".get_called_class()."::".__FUNCTION__."' not implemented");
+    }
     
     
 }


### PR DESCRIPTION
... class level. but since they are static they can't be. +it gives a strict runtime notice error.

thus making them not abstract and making them throw a runtime notice error seems more appropriate.
