### PR TITLE
Add xhprof/xhprof_lib/config.php to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # Netbeans project files
 #
 /nbproject
+/xhprof_lib/config.php


### PR DESCRIPTION
Add the config file to .gitignore

This should prevent people accidentally uploading the config file on pull requests

Also helps us use this as a submodule of a larger project :)
