### PR TITLE
Compatibility issue #51 has been fixed

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -247,7 +247,7 @@ CREATE TABLE `details` (
   public static function getNextAssoc($resultSet)
   {
     $class = self::getDbClass();
-    return $class::getNextAssoc($resultSet);
+	return call_user_func_array(array($class, "getNextAssoc"), array($resultSet));
   }
   
   /**


### PR DESCRIPTION
"call_user_func_array" used instead of $class::method(), which causes problems on some systems.
