### PR TITLE
Quick fix to make xhgui compatible with PHP 5.2.

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -247,7 +247,7 @@ CREATE TABLE `details` (
   public static function getNextAssoc($resultSet)
   {
     $class = self::getDbClass();
-    return $class::getNextAssoc($resultSet);
+    return call_user_func($class . '::getNextAssoc', $resultSet);
   }
   
   /**


### PR DESCRIPTION
Replace static function call on class variable with a call_user_func() to make xhgui compatible with PHP 5.2.
