### PR TITLE
Display error message for proc_open errors

### DIFF
--- a/xhprof_lib/utils/callgraph_utils.php
+++ b/xhprof_lib/utils/callgraph_utils.php
@@ -139,6 +139,12 @@ function xhprof_generate_image_by_dot($dot_script, $type) {
     return $output;
   }
   print "failed to shell execute cmd=\"$cmd\"\n";
+
+  $error = error_get_last();
+  if (isset($error['message'])) {
+    print($error['message'] . "\n");
+  }
+
   exit();
 }
 


### PR DESCRIPTION
Example of message:

> proc_open() has been disabled for security reasons 
