### PR TITLE
Added ability to ignore specified domains.

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -99,6 +99,17 @@ unset($ignoreURLs);
 
 unset($url);
 
+// Certain domains should never be profiled.
+foreach($ignoreDomains as $domain){
+    if (stripos($_SERVER['HTTP_HOST'], $domain) !== FALSE)
+    {
+        $_xhprof['doprofile'] = false;
+        break;
+    }
+}
+unset($ignoreDomains);
+unset($domain);
+
 //Display warning if extension not available
 if (extension_loaded('xhprof') && $_xhprof['doprofile'] === true) {
     include_once dirname(__FILE__) . '/../xhprof_lib/utils/xhprof_lib.php';

--- a/xhprof_lib/config.sample.php
+++ b/xhprof_lib/config.sample.php
@@ -36,6 +36,8 @@ $_xhprof['dot_errfile'] = '/tmp/xh_dot.err';
 
 $ignoreURLs = array();
 
+$ignoreDomains = array();
+
 $exceptionURLs = array();
 
 $exceptionPostURLs = array();


### PR DESCRIPTION
We want to profile every almost site on our dev server, and each of them is set up as a virtual host with a subdomain. We don't need to profile things like xhprof itself or phpMyAdmin, so we want to disable profiling for those domains to keep things clean - it's not really feasible to exclude based on REQUEST_URI like is done for $ignoreURLs, so I added another option.
