### PR TITLE
add explicit link to index.php

### DIFF
--- a/xhprof_html/index.php
+++ b/xhprof_html/index.php
@@ -167,7 +167,7 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     {
         $url = urlencode($row['url']);
         $html['url'] = htmlentities($row['url'], ENT_QUOTES, 'UTF-8');
-        echo "\t<tr><td><a href=\"?geturl={$url}\">{$html['url']}</a></td><td>{$row['count']}</td><td>" . number_format($row['total_wall']) . " ms</td><td>" . number_format($row['avg_wall']) . " ms</td></tr>\n";
+        echo "\t<tr><td><a href=\"index.php?geturl={$url}\">{$html['url']}</a></td><td>{$row['count']}</td><td>" . number_format($row['total_wall']) . " ms</td><td>" . number_format($row['avg_wall']) . " ms</td></tr>\n";
     }
     echo "</tbody>\n";
     echo "</table>\n";   


### PR DESCRIPTION
on some servers (nginx for example), index.php are not always the default file, so adding it explictly avoid to have broken links
