### PR TITLE
fixed bugs of getting timestamp

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -300,7 +300,7 @@ CREATE TABLE `details` (
   */
   public function getUrlStats($data)
   {
-      $data['select'] = '`id`, '.$this->db->unixTimestamp(`timestamp`).' as `timestamp`, `pmu`, `wt`, `cpu`';   
+      $data['select'] = '`id`, '.$this->db->unixTimestamp('timestamp').' as `timestamp`, `pmu`, `wt`, `cpu`';
       $rs = $this->getRuns($data);
       return $rs;
   }


### PR DESCRIPTION
I fixed bugs of getting timestamp.
The xAxis of chart was same timestamp cause parameter of $this->db->unixTimestamp() was empty.
