### PR TITLE
Fixes backslash issue.

### DIFF
--- a/xhprof_lib/templates/profChart.phtml
+++ b/xhprof_lib/templates/profChart.phtml
@@ -68,7 +68,7 @@
                     $other+= $dataPoint['excl_wt'];
                 }else
                 {
-                    echo "['{$dataPoint['fn']}', {$dataPoint['excl_wt']}],\n";
+                    echo "['" . addslashes($dataPoint['fn']) . "', {$dataPoint['excl_wt']}],\n";
                 }
             }
             echo "['Other', $other]";


### PR DESCRIPTION
The backslash in JS is also interpreted inside quote.
For example a 'lithium\util\String:insert()' string will throw a JS error since '\u' expect to be followed by an unicode value.