### PR TITLE
Update code to PSR-2 standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+cache:
+  directories:
+    - $HOME/.composer/cache
+before_script:
+    - composer install --prefer-dist --dev -n
+    - composer dump-autoload
+script:
+# Uncomment next line if & when unit tests are implemented
+#  - php vendor/bin/phpunit test/unit
+  - php vendor/bin/phpcs xhprof_html/ --standard=PSR2 --report=summary -p
+  - php vendor/bin/phpcs xhprof_lib/ --standard=PSR2 --report=summary -p
+  - php vendor/bin/phpcs external/ --standard=PSR2 --report=summary -p

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "squizlabs/php_codesniffer": "2.*"
+    }
+}

--- a/external/footer.php
+++ b/external/footer.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
 }
 
 if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
@@ -12,8 +12,7 @@ if ($_xhprof['ext_name'] && $_xhprof['doprofile'] === true) {
     $xhprof_data = call_user_func($_xhprof['ext_name'].'_disable');
     $xhprof_runs = new XHProfRuns_Default();
     $run_id = $xhprof_runs->save_run($xhprof_data, $profiler_namespace, null, $_xhprof);
-    if ($_xhprof['display'] === true && PHP_SAPI != 'cli' && !isset($isAjax))
-    {
+    if ($_xhprof['display'] === true && PHP_SAPI != 'cli' && !isset($isAjax)) {
         // url to the XHProf UI libraries (change the host name and path)
         $profiler_url = sprintf($_xhprof['url'].'/index.php?run=%s&source=%s', $run_id, $profiler_namespace);
         echo '<a href="'. $profiler_url .'" target="_blank">Profiler output</a>';

--- a/external/header.php
+++ b/external/header.php
@@ -1,25 +1,23 @@
 <?php
 if (PHP_SAPI == 'cli') {
-  $_SERVER['REMOTE_ADDR'] = null;
-  $_SERVER['HTTP_HOST'] = null;
-  $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'];
+    $_SERVER['REMOTE_ADDR'] = null;
+    $_SERVER['HTTP_HOST'] = null;
+    $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'];
 }
 
 include(dirname(__FILE__) . '/../xhprof_lib/config.php');
 
 function getExtensionName()
 {
-    if (extension_loaded('tideways'))
-    {
+    if (extension_loaded('tideways')) {
         return 'tideways';
-    }elseif(extension_loaded('xhprof')) {
+    } elseif (extension_loaded('xhprof')) {
         return 'xhprof';
     }
     return false;
 }
 $_xhprof['ext_name'] = getExtensionName();
-if($_xhprof['ext_name'])
-{
+if ($_xhprof['ext_name']) {
     $flagsCpu = constant(strtoupper($_xhprof['ext_name']).'_FLAGS_CPU');
     $flagsMemory = constant(strtoupper($_xhprof['ext_name']).'_FLAGS_MEMORY');
     $envVarName = strtoupper($_xhprof['ext_name']).'_PROFILE';
@@ -29,97 +27,84 @@ if($_xhprof['ext_name'])
 //I'm Magic :)
 class visibilitator
 {
-	public static function __callstatic($name, $arguments)
-	{
-		$func_name = array_shift($arguments);
-		//var_dump($name);
-		//var_dump("arguments" ,$arguments);
-		//var_dump($func_name);
-		if (is_array($func_name))
-		{
-			list($a, $b) = $func_name;
-			if (count($arguments) == 0)
-			{
-				$arguments = $arguments[0];
-			}
-			return call_user_func_array(array($a, $b), $arguments);
-			//echo "array call  -> $b ($arguments)";
-		}else {
-			call_user_func_array($func_name, $arguments);
-		}
-	}
+    public static function __callstatic($name, $arguments)
+    {
+        $func_name = array_shift($arguments);
+        //var_dump($name);
+        //var_dump("arguments" ,$arguments);
+        //var_dump($func_name);
+        if (is_array($func_name)) {
+            list($a, $b) = $func_name;
+            if (count($arguments) == 0) {
+                $arguments = $arguments[0];
+            }
+            return call_user_func_array(array($a, $b), $arguments);
+            //echo "array call  -> $b ($arguments)";
+        } else {
+            call_user_func_array($func_name, $arguments);
+        }
+    }
 }
 
 // Only users from authorized IP addresses may control Profiling
-if ($controlIPs === false || in_array($_SERVER['REMOTE_ADDR'], $controlIPs) || PHP_SAPI == 'cli')
-{
+if ($controlIPs === false || in_array($_SERVER['REMOTE_ADDR'], $controlIPs) || PHP_SAPI == 'cli') {
   /* Backwards Compatibility getparam check*/
-  if (!isset($_xhprof['getparam']))
-  {
-      $_xhprof['getparam'] = '_profile';
-  }
+    if (!isset($_xhprof['getparam'])) {
+        $_xhprof['getparam'] = '_profile';
+    }
   
-  if (isset($_GET[$_xhprof['getparam']]))
-  {
-    //Give them a cookie to hold status, and redirect back to the same page
-    setcookie('_profile', $_GET[$_xhprof['getparam']]);
-    $newURI = str_replace(array($_xhprof['getparam'].'=1',$_xhprof['getparam'].'=0'), '', $_SERVER['REQUEST_URI']);
-    header("Location: $newURI");
-    exit;
-  }
+    if (isset($_GET[$_xhprof['getparam']])) {
+        //Give them a cookie to hold status, and redirect back to the same page
+        setcookie('_profile', $_GET[$_xhprof['getparam']]);
+        $newURI = str_replace(array($_xhprof['getparam'].'=1',$_xhprof['getparam'].'=0'), '', $_SERVER['REQUEST_URI']);
+        header("Location: $newURI");
+        exit;
+    }
   
-  if (isset($_COOKIE['_profile']) && $_COOKIE['_profile'] 
-          || PHP_SAPI == 'cli' && ( (isset($_SERVER[$envVarName]) && $_SERVER[$envVarName]) 
-          || (isset($_ENV[$envVarName]) && $_ENV[$envVarName])))
-  {
-      $_xhprof['display'] = true;
-      $_xhprof['doprofile'] = true;
-      $_xhprof['type'] = 1;
-  }
-  unset($envVarName);
+    if (isset($_COOKIE['_profile']) && $_COOKIE['_profile']
+          || PHP_SAPI == 'cli' && ( (isset($_SERVER[$envVarName]) && $_SERVER[$envVarName])
+          || (isset($_ENV[$envVarName]) && $_ENV[$envVarName]))) {
+        $_xhprof['display'] = true;
+        $_xhprof['doprofile'] = true;
+        $_xhprof['type'] = 1;
+    }
+    unset($envVarName);
 }
 
 
 //Certain URLs should never have a link displayed. Think images, xml, etc. 
-foreach($exceptionURLs as $url)
-{
-    if (stripos($_SERVER['REQUEST_URI'], $url) !== FALSE)
-    {
+foreach ($exceptionURLs as $url) {
+    if (stripos($_SERVER['REQUEST_URI'], $url) !== false) {
         $_xhprof['display'] = false;
         header('X-XHProf-No-Display: Trueness');
         break;
-    }    
+    }
 }
 unset($exceptionURLs);
 
 //Certain urls should have their POST data omitted. Think login forms, other privlidged info
 $_xhprof['savepost'] = true;
-foreach ($exceptionPostURLs as $url)
-{
-    if (stripos($_SERVER['REQUEST_URI'], $url) !== FALSE)
-    {
+foreach ($exceptionPostURLs as $url) {
+    if (stripos($_SERVER['REQUEST_URI'], $url) !== false) {
         $_xhprof['savepost'] = false;
         break;
-    }    
+    }
 }
 unset($exceptionPostURLs);
 
 //Determine wether or not to profile this URL randomly
-if ($_xhprof['doprofile'] === false)
-{
+if ($_xhprof['doprofile'] === false) {
     //Profile weighting, one in one hundred requests will be profiled without being specifically requested
-    if (rand(1, $weight) == 1)
-    {
+    if (rand(1, $weight) == 1) {
         $_xhprof['doprofile'] = true;
         $_xhprof['type'] = 0;
-    } 
+    }
 }
 unset($weight);
 
 // Certain URLS should never be profiled.
-foreach($ignoreURLs as $url){
-    if (stripos($_SERVER['REQUEST_URI'], $url) !== FALSE)
-    {
+foreach ($ignoreURLs as $url) {
+    if (stripos($_SERVER['REQUEST_URI'], $url) !== false) {
         $_xhprof['doprofile'] = false;
         break;
     }
@@ -129,9 +114,8 @@ unset($ignoreURLs);
 unset($url);
 
 // Certain domains should never be profiled.
-foreach($ignoreDomains as $domain){
-    if (stripos($_SERVER['HTTP_HOST'], $domain) !== FALSE)
-    {
+foreach ($ignoreDomains as $domain) {
+    if (stripos($_SERVER['HTTP_HOST'], $domain) !== false) {
         $_xhprof['doprofile'] = false;
         break;
     }
@@ -143,22 +127,21 @@ unset($domain);
 if ($_xhprof['ext_name'] && $_xhprof['doprofile'] === true) {
     include_once dirname(__FILE__) . '/../xhprof_lib/utils/xhprof_lib.php';
     include_once dirname(__FILE__) . '/../xhprof_lib/utils/xhprof_runs.php';
-    if (isset($ignoredFunctions) && is_array($ignoredFunctions) && !empty($ignoredFunctions)) {   
+    if (isset($ignoredFunctions) && is_array($ignoredFunctions) && !empty($ignoredFunctions)) {
         call_user_func($_xhprof['ext_name'].'_enable', $flagsCpu + $flagsMemory, array('ignored_functions' => $ignoredFunctions));
     } else {
         call_user_func($_xhprof['ext_name'].'_enable', $flagsCpu + $flagsMemory);
     }
     unset($flagsCpu);
     unset($flagsMemory);
-    
-}elseif(false === $_xhprof['ext_name'] && $_xhprof['display'] === true)
-{
+} elseif (false === $_xhprof['ext_name'] && $_xhprof['display'] === true) {
     $message = 'Warning! Unable to profile run, tideways or xhprof extension not loaded';
     trigger_error($message, E_USER_WARNING);
 }
 unset($flagsCpu);
     unset($flagsMemory);
-function xhprof_shutdown_function() {
+function xhprof_shutdown_function()
+{
     global $_xhprof;
     require dirname(__FILE__).'/footer.php';
 }

--- a/xhprof_html/callgraph.php
+++ b/xhprof_html/callgraph.php
@@ -28,17 +28,16 @@
  *
  * @author Changhao Jiang (cjiang@facebook.com)
  */
-require_once ("../xhprof_lib/config.php");
+require_once("../xhprof_lib/config.php");
 
-if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs))
-{
-  die("You do not have permission to view this page.");
+if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs)) {
+    die("You do not have permission to view this page.");
 }
 
 // by default assume that xhprof_html & xhprof_lib directories
 // are at the same level.
 if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
 }
 
 include_once XHPROF_LIB_ROOT . '/display/xhprof.php';
@@ -78,22 +77,35 @@ xhprof_param_init($params);
 
 // if invalid value specified for threshold, then use the default
 if ($threshold < 0 || $threshold > 1) {
-  $threshold = $params['threshold'][1];
+    $threshold = $params['threshold'][1];
 }
 
 // if invalid value specified for type, use the default
 if (!array_key_exists($type, $xhprof_legal_image_types)) {
-  $type = $params['type'][1]; // default image type.
+    $type = $params['type'][1]; // default image type.
 }
 
 $xhprof_runs_impl = new XHProfRuns_Default();
 
 if (!empty($run)) {
   // single run call graph image generation
-  xhprof_render_image($xhprof_runs_impl, $run, $type,
-                      $threshold, $func, $source, $critical);
+    xhprof_render_image(
+        $xhprof_runs_impl,
+        $run,
+        $type,
+        $threshold,
+        $func,
+        $source,
+        $critical
+    );
 } else {
   // diff report call graph image generation
-  xhprof_render_diff_image($xhprof_runs_impl, $run1, $run2,
-                           $type, $threshold, $source);
+    xhprof_render_diff_image(
+        $xhprof_runs_impl,
+        $run1,
+        $run2,
+        $type,
+        $threshold,
+        $source
+    );
 }

--- a/xhprof_html/index.php
+++ b/xhprof_html/index.php
@@ -1,28 +1,34 @@
 <?php
-if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
-}
-require_once (XHPROF_LIB_ROOT . "/config.php");
-include_once XHPROF_LIB_ROOT . '/display/xhprof.php';
-include (XHPROF_LIB_ROOT . "/utils/common.php");
 
-if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs))
-{
-  die("You do not have permission to view this page.");
+if (!defined('XHPROF_LIB_ROOT')) {
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
+}
+
+if (!file_exists(XHPROF_LIB_ROOT . '/config.php')) {
+    die(sprintf("Please create the file %s with your own settings.", XHPROF_LIB_ROOT . '/config.php'));
+}
+
+require_once XHPROF_LIB_ROOT . '/config.php';
+require_once XHPROF_LIB_ROOT . '/display/xhprof.php';
+require_once XHPROF_LIB_ROOT . "/utils/common.php";
+
+if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs, true)) {
+    die('You do not have permission to view this page.');
 }
 
 unset($controlIPs);
 
 // param name, its type, and default value
-$params = array('run'        => array(XHPROF_STRING_PARAM, ''),
-                'wts'        => array(XHPROF_STRING_PARAM, ''),
-                'symbol'     => array(XHPROF_STRING_PARAM, ''),
-                'sort'       => array(XHPROF_STRING_PARAM, 'wt'), // wall time
-                'run1'       => array(XHPROF_STRING_PARAM, ''),
-                'run2'       => array(XHPROF_STRING_PARAM, ''),
-                'source'     => array(XHPROF_STRING_PARAM, 'xhprof'),
-                'all'        => array(XHPROF_UINT_PARAM, 0),
-                );
+$params = array(
+    'run'        => array(XHPROF_STRING_PARAM, ''),
+    'wts'        => array(XHPROF_STRING_PARAM, ''),
+    'symbol'     => array(XHPROF_STRING_PARAM, ''),
+    'sort'       => array(XHPROF_STRING_PARAM, 'wt'), // wall time
+    'run1'       => array(XHPROF_STRING_PARAM, ''),
+    'run2'       => array(XHPROF_STRING_PARAM, ''),
+    'source'     => array(XHPROF_STRING_PARAM, 'xhprof'),
+    'all'        => array(XHPROF_UINT_PARAM, 0),
+);
 
 // pull values of these params, and create named globals for each param
 xhprof_param_init($params);
@@ -32,13 +38,13 @@ xhprof_param_init($params);
    to be preserved for the next page. unset all unwanted keys in $params.
  */
 foreach ($params as $k => $v) {
-  $params[$k] = $$k;
+    $params[$k] = $$k;
 
-  // unset key from params that are using default values. So URLs aren't
-  // ridiculously long.
-  if ($params[$k] == $v[1]) {
-    unset($params[$k]);
-  }
+    // unset key from params that are using default values. So URLs aren't
+    // ridiculously long.
+    if ($params[$k] == $v[1]) {
+        unset($params[$k]);
+    }
 }
 
 
@@ -56,35 +62,40 @@ $serverFilter = getFilter('server_filter');
 
 $domainsRS = $xhprof_runs_impl->getDistinct(array('column' => 'server name'));
 $domainFilterOptions = array("None");
-while ($row = XHProfRuns_Default::getNextAssoc($domainsRS))
-{
-	$domainFilterOptions[] = $row['server name'];
+while ($row = XHProfRuns_Default::getNextAssoc($domainsRS)) {
+    $domainFilterOptions[] = $row['server name'];
 }
 
 $serverRS = $xhprof_runs_impl->getDistinct(array('column' => 'server_id'));
 $serverFilterOptions = array("None");
-while ($row = XHProfRuns_Default::getNextAssoc($serverRS))
-{
-	$serverFilterOptions[] = $row['server_id'];
+while ($row = XHProfRuns_Default::getNextAssoc($serverRS)) {
+    $serverFilterOptions[] = $row['server_id'];
 }
 
 $criteria = array();
-if (!is_null($domainFilter))
-{
-  $criteria['server name'] = $domainFilter;
+if (!is_null($domainFilter)) {
+    $criteria['server name'] = $domainFilter;
 }
-if (!is_null($serverFilter))
-{
-  $criteria['server_id'] = $serverFilter;
+if (!is_null($serverFilter)) {
+    $criteria['server_id'] = $serverFilter;
 }
-$_xh_header = "";
-if(isset($_GET['run1']) || isset($_GET['run']))
-{
-    include ("../xhprof_lib/templates/header.phtml");
-	displayXHProfReport($xhprof_runs_impl, $params, $source, $run, $wts,
-	                    $symbol, $sort, $run1, $run2);
-}elseif (isset($_GET['geturl']))
-{
+
+$_xh_header = '';
+
+if (isset($_GET['run1']) || isset($_GET['run'])) {
+    include("../xhprof_lib/templates/header.phtml");
+    displayXHProfReport(
+        $xhprof_runs_impl,
+        $params,
+        $source,
+        $run,
+        $wts,
+        $symbol,
+        $sort,
+        $run1,
+        $run2
+    );
+} elseif (isset($_GET['geturl'])) {
     $last = (isset($_GET['last'])) ?  $_GET['last'] : 100;
     $last = (int) $last;
     $criteria['url'] = $_GET['geturl'];
@@ -94,14 +105,13 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     list($header, $body) = showChart($rs, true);
     $_xh_header .= $header;
 
-    include ("../xhprof_lib/templates/header.phtml");
+    include("../xhprof_lib/templates/header.phtml");
     $rs = $xhprof_runs_impl->getRuns($criteria);
-    include ("../xhprof_lib/templates/emptyBody.phtml");
+    include("../xhprof_lib/templates/emptyBody.phtml");
 
     $url = htmlentities($_GET['geturl'], ENT_QUOTES, "UTF-8");
     displayRuns($rs, "Runs with URL: $url");
-}elseif (isset($_GET['getcurl']))
-{
+} elseif (isset($_GET['getcurl'])) {
     $last = (isset($_GET['last'])) ?  $_GET['last'] : 100;
     $last = (int) $last;
     $criteria['c_url'] = $_GET['getcurl'];
@@ -111,19 +121,17 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     $rs = $xhprof_runs_impl->getUrlStats($criteria);
     list($header, $body) = showChart($rs, true);
     $_xh_header .= $header;
-    include ("../xhprof_lib/templates/header.phtml");
+    include("../xhprof_lib/templates/header.phtml");
 
     $url = htmlentities($_GET['getcurl'], ENT_QUOTES, "UTF-8");
     $rs = $xhprof_runs_impl->getRuns($criteria);
     include("../xhprof_lib/templates/emptyBody.phtml");
     displayRuns($rs, "Runs with Simplified URL: $url");
-}elseif (isset($_GET['getruns']))
-{
-    include ("../xhprof_lib/templates/header.phtml");
+} elseif (isset($_GET['getruns'])) {
+    include("../xhprof_lib/templates/header.phtml");
     $days = (int) $_GET['days'];
 
-    switch ($_GET['getruns'])
-    {
+    switch ($_GET['getruns']) {
         case "cpu":
             $load = "cpu";
             break;
@@ -140,19 +148,16 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     $criteria['where'] = "DATE_SUB(CURDATE(), INTERVAL $days DAY) <= `timestamp`";
     $rs = $xhprof_runs_impl->getRuns($criteria);
     displayRuns($rs, "Worst runs by $load");
-}elseif(isset($_GET['hit']))
-{
-    include ("../xhprof_lib/templates/header.phtml");
+} elseif (isset($_GET['hit'])) {
+    include("../xhprof_lib/templates/header.phtml");
     $last = (isset($_GET['hit'])) ?  $_GET['hit'] : 25;
     $last = (int) $last;
     $days = (isset($_GET['days'])) ?  $_GET['days'] : 1;
     $days = (int) $days;
-    if (isset($_GET['type']) && ($_GET['type'] === 'url' OR $_GET['type'] = 'curl'))
-    {
-      $type = $_GET['type'];
-    }else
-    {
-      $type = 'url';
+    if (isset($_GET['type']) && ($_GET['type'] === 'url' or $_GET['type'] = 'curl')) {
+        $type = $_GET['type'];
+    } else {
+        $type = 'url';
     }
 
     $criteria['limit'] = $last;
@@ -161,13 +166,15 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     $resultSet = $xhprof_runs_impl->getHardHit($criteria);
 
     echo "<h1 class=\"runTitle\">Hardest Hit</h1>\n";
-    echo "<table id=\"box-table-a\" class=\"tablesorter\" summary=\"Stats\"><thead><tr><th>URL</th><th>Hits</th><th class=\"{sorter: 'numeric'}\">Total Wall Time</th><th>Avg Wall Time</th></tr></thead>";
+    echo "<table id=\"box-table-a\" class=\"tablesorter\" summary=\"Stats\"><thead><tr><th>URL</th><th>Hits</th>" .
+        "<th class=\"{sorter: 'numeric'}\">Total Wall Time</th><th>Avg Wall Time</th></tr></thead>";
     echo "<tbody>\n";
-    while ($row = XHProfRuns_Default::getNextAssoc($resultSet))
-    {
+    while ($row = XHProfRuns_Default::getNextAssoc($resultSet)) {
         $url = urlencode($row['url']);
         $html['url'] = htmlentities($row['url'], ENT_QUOTES, 'UTF-8');
-        echo "\t<tr><td><a href=\"?geturl={$url}\">{$html['url']}</a></td><td>{$row['count']}</td><td>" . number_format($row['total_wall']) . " ms</td><td>" . number_format($row['avg_wall']) . " ms</td></tr>\n";
+        echo "\t<tr><td><a href=\"?geturl={$url}\">{$html['url']}</a></td><td>{$row['count']}</td>" .
+            "<td>" . number_format($row['total_wall']) . " ms</td>" .
+            "<td>" . number_format($row['avg_wall']) . " ms</td></tr>\n";
     }
     echo "</tbody>\n";
     echo "</table>\n";
@@ -175,35 +182,34 @@ if(isset($_GET['run1']) || isset($_GET['run']))
     <script type="text/javascript">
     $(document).ready(function() {
       $.tablesorter.addParser({
-	  id: 'pretty',
-	  is: function(s) {
-	      return false;
-	  },
-	  format: function(s) {
-	      s = s.replace(/ ms/g,"");
-	      return s.replace(/,/g,"");
-	  },
-	  // set type, either numeric or text
-	  type: 'numeric'
+      id: 'pretty',
+      is: function(s) {
+          return false;
+      },
+      format: function(s) {
+          s = s.replace(/ ms/g,"");
+          return s.replace(/,/g,"");
+      },
+      // set type, either numeric or text
+      type: 'numeric'
       });
       $(function() {
-	  $("table").tablesorter({
-	      headers: {
-		  2: {
-		      sorter:'pretty'
-		  },
-		  3: {
-		      sorter:'pretty'
-		  }
-	      }
-	  });
+      $("table").tablesorter({
+          headers: {
+          2: {
+              sorter:'pretty'
+          },
+          3: {
+              sorter:'pretty'
+          }
+          }
+      });
       });
     });
     </script>
 CODESE;
-}else
-{
-    include ("../xhprof_lib/templates/header.phtml");
+} else {
+    include("../xhprof_lib/templates/header.phtml");
     $last = (isset($_GET['last'])) ?  $_GET['last'] : 25;
     $last = (int) $last;
     $criteria['order by'] = "timestamp";
@@ -212,4 +218,4 @@ CODESE;
     displayRuns($rs, "Last $last Runs");
 }
 
-include ("../xhprof_lib/templates/footer.phtml");
+include("../xhprof_lib/templates/footer.phtml");

--- a/xhprof_lib/display/typeahead_common.php
+++ b/xhprof_lib/display/typeahead_common.php
@@ -39,42 +39,38 @@ $params = array('q'          => array(XHPROF_STRING_PARAM, ''),
 xhprof_param_init($params);
 
 if (!empty($run)) {
-
   // single run mode
-  $raw_data = $xhprof_runs_impl->get_run($run, $source, $desc_unused);
-  $functions = xhprof_get_matching_functions($q, $raw_data);
-
-} else if (!empty($run1) && !empty($run2)) {
-
+    $raw_data = $xhprof_runs_impl->get_run($run, $source, $desc_unused);
+    $functions = xhprof_get_matching_functions($q, $raw_data);
+} elseif (!empty($run1) && !empty($run2)) {
   // diff mode
-  $raw_data = $xhprof_runs_impl->get_run($run1, $source, $desc_unused);
-  $functions1 = xhprof_get_matching_functions($q, $raw_data);
+    $raw_data = $xhprof_runs_impl->get_run($run1, $source, $desc_unused);
+    $functions1 = xhprof_get_matching_functions($q, $raw_data);
 
-  $raw_data = $xhprof_runs_impl->get_run($run2, $source, $desc_unused);
-  $functions2 = xhprof_get_matching_functions($q, $raw_data);
+    $raw_data = $xhprof_runs_impl->get_run($run2, $source, $desc_unused);
+    $functions2 = xhprof_get_matching_functions($q, $raw_data);
 
 
-  $functions = array_unique(array_merge($functions1, $functions2));
-  asort($functions);
+    $functions = array_unique(array_merge($functions1, $functions2));
+    asort($functions);
 } else {
-  xhprof_error("no valid runs specified to typeahead endpoint");
-  $functions = array();
+    xhprof_error("no valid runs specified to typeahead endpoint");
+    $functions = array();
 }
 
 // If exact match is present move it to the front
 if (in_array($q, $functions)) {
-  $old_functions = $functions;
+    $old_functions = $functions;
 
-  $functions = array($q);
-  foreach ($old_functions as $f) {
-    // exact match case has already been added to the front
-    if ($f != $q) {
-      $functions[] =$f;
+    $functions = array($q);
+    foreach ($old_functions as $f) {
+        // exact match case has already been added to the front
+        if ($f != $q) {
+            $functions[] =$f;
+        }
     }
-  }
 }
 
 foreach ($functions as $f) {
-  echo $f."\n";
+    echo $f."\n";
 }
-

--- a/xhprof_lib/display/xhprof.php
+++ b/xhprof_lib/display/xhprof.php
@@ -30,7 +30,7 @@
 
 if (!defined('XHPROF_LIB_ROOT')) {
   // by default, the parent directory is XHPROF lib root
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)));
+    define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)));
 }
 
 include_once XHPROF_LIB_ROOT . '/utils/xhprof_lib.php';
@@ -55,28 +55,29 @@ $base_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
  * can be specified in the generated HTML.
  *
  */
-function xhprof_include_js_css($ui_dir_url_path = null) {
+function xhprof_include_js_css($ui_dir_url_path = null)
+{
 
-  if (empty($ui_dir_url_path)) {
-    $ui_dir_url_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
-  }
+    if (empty($ui_dir_url_path)) {
+        $ui_dir_url_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
+    }
 
   // style sheets
-  echo "<link href='$ui_dir_url_path/css/xhprof.css' rel='stylesheet' ".
+    echo "<link href='$ui_dir_url_path/css/xhprof.css' rel='stylesheet' ".
     " type='text/css'></link>";
-  echo "<link href='$ui_dir_url_path/jquery/jquery.tooltip.css' ".
+    echo "<link href='$ui_dir_url_path/jquery/jquery.tooltip.css' ".
     " rel='stylesheet' type='text/css'></link>";
-  echo "<link href='$ui_dir_url_path/jquery/jquery.autocomplete.css' ".
+    echo "<link href='$ui_dir_url_path/jquery/jquery.autocomplete.css' ".
     " rel='stylesheet' type='text/css'></link>";
 
   // javascript
-  echo "<script src='$ui_dir_url_path/jquery/jquery-1.2.6.js'>".
+    echo "<script src='$ui_dir_url_path/jquery/jquery-1.2.6.js'>".
        "</script>";
-  echo "<script src='$ui_dir_url_path/jquery/jquery.tooltip.js'>".
+    echo "<script src='$ui_dir_url_path/jquery/jquery.tooltip.js'>".
        "</script>";
-  echo "<script src='$ui_dir_url_path/jquery/jquery.autocomplete.js'>"
+    echo "<script src='$ui_dir_url_path/jquery/jquery.autocomplete.js'>"
        ."</script>";
-  echo "<script src='$ui_dir_url_path/js/xhprof_report.js'></script>";
+    echo "<script src='$ui_dir_url_path/js/xhprof_report.js'></script>";
 }
 
 
@@ -96,35 +97,38 @@ function xhprof_include_js_css($ui_dir_url_path = null) {
  *   4000.0001 ==> 4,000
  *
  */
-function xhprof_count_format($num) {
-  $num = round($num, 3);
-  if (round($num) == $num) {
-    return number_format($num);
-  } else {
-    return number_format($num, 3);
-  }
+function xhprof_count_format($num)
+{
+    $num = round($num, 3);
+    if (round($num) == $num) {
+        return number_format($num);
+    } else {
+        return number_format($num, 3);
+    }
 }
 
-function xhprof_percent_format($s, $precision = 1) {
-  return sprintf('%.'.$precision.'f%%', 100*$s);
+function xhprof_percent_format($s, $precision = 1)
+{
+    return sprintf('%.'.$precision.'f%%', 100*$s);
 }
 
 /**
  * Implodes the text for a bunch of actions (such as links, forms,
  * into a HTML list and returns the text.
  */
-function xhprof_render_actions($actions) {
-  $out = array( );
-  $out[] = "<div>\n";
-  if (count($actions)) {
-    $out[] = "<ul class=\"xhprof_actions\">\n";
-    foreach ($actions as $action) {
-      $out[] = "\t<li>".$action."</li>\n";
+function xhprof_render_actions($actions)
+{
+    $out = array( );
+    $out[] = "<div>\n";
+    if (count($actions)) {
+        $out[] = "<ul class=\"xhprof_actions\">\n";
+        foreach ($actions as $action) {
+            $out[] = "\t<li>".$action."</li>\n";
+        }
+        $out[] = "</ul>\n";
     }
-    $out[] = "</ul>\n";
-  }
-  $out[] = "</div>\n";
-  return implode('', $out);
+    $out[] = "</div>\n";
+    return implode('', $out);
 }
 
 
@@ -144,61 +148,71 @@ function xhprof_render_actions($actions) {
  * @param raw-str  $dir
  * @param raw-str  $rel
  */
-function xhprof_render_link($content, $href, $class='', $id='', $title='',
-                            $target='',
-                            $onclick='', $style='', $access='', $onmouseover='',
-                            $onmouseout='', $onmousedown='') {
+function xhprof_render_link(
+    $content,
+    $href,
+    $class = '',
+    $id = '',
+    $title = '',
+    $target = '',
+    $onclick = '',
+    $style = '',
+    $access = '',
+    $onmouseover = '',
+    $onmouseout = '',
+    $onmousedown = ''
+) {
 
-  if (!$content) {
-    return '';
-  }
+    if (!$content) {
+        return '';
+    }
 
-  if ($href) {
-    $link = '<a href="' . ($href) . '"';
-  } else {
-    $link = '<span';
-  }
+    if ($href) {
+        $link = '<a href="' . ($href) . '"';
+    } else {
+        $link = '<span';
+    }
 
-  if ($class) {
-    $link .= ' class="' . ($class) . '"';
-  }
-  if ($id) {
-    $link .= ' id="' . ($id) . '"';
-  }
-  if ($title) {
-    $link .= ' title="' . ($title) . '"';
-  }
-  if ($target) {
-    $link .= ' target="' . ($target) . '"';
-  }
-  if ($onclick && $href) {
-    $link .= ' onclick="' . ($onclick) . '"';
-  }
-  if ($style && $href) {
-    $link .= ' style="' . ($style) . '"';
-  }
-  if ($access && $href) {
-    $link .= ' accesskey="' . ($access) . '"';
-  }
-  if ($onmouseover) {
-    $link .= ' onmouseover="' . ($onmouseover) . '"';
-  }
-  if ($onmouseout) {
-    $link .= ' onmouseout="' . ($onmouseout) . '"';
-  }
-  if ($onmousedown) {
-    $link .= ' onmousedown="' . ($onmousedown) . '"';
-  }
+    if ($class) {
+        $link .= ' class="' . ($class) . '"';
+    }
+    if ($id) {
+        $link .= ' id="' . ($id) . '"';
+    }
+    if ($title) {
+        $link .= ' title="' . ($title) . '"';
+    }
+    if ($target) {
+        $link .= ' target="' . ($target) . '"';
+    }
+    if ($onclick && $href) {
+        $link .= ' onclick="' . ($onclick) . '"';
+    }
+    if ($style && $href) {
+        $link .= ' style="' . ($style) . '"';
+    }
+    if ($access && $href) {
+        $link .= ' accesskey="' . ($access) . '"';
+    }
+    if ($onmouseover) {
+        $link .= ' onmouseover="' . ($onmouseover) . '"';
+    }
+    if ($onmouseout) {
+        $link .= ' onmouseout="' . ($onmouseout) . '"';
+    }
+    if ($onmousedown) {
+        $link .= ' onmousedown="' . ($onmousedown) . '"';
+    }
 
-  $link .= '>';
-  $link .= $content;
-  if ($href) {
-    $link .= '</a>';
-  } else {
-    $link .= '</span>';
-  }
+    $link .= '>';
+    $link .= $content;
+    if ($href) {
+        $link .= '</a>';
+    } else {
+        $link .= '</span>';
+    }
 
-  return $link;
+    return $link;
 }
 
 
@@ -382,35 +396,34 @@ $metrics = null;
  */
 function sort_cbk($a, $b)
 {
-  global $sort_col;
-  global $diff_mode;
+    global $sort_col;
+    global $diff_mode;
 
-  if ($sort_col == "fn") {
+    if ($sort_col == "fn") {
+        // case insensitive ascending sort for function names
+        $left = strtoupper($a["fn"]);
+        $right = strtoupper($b["fn"]);
 
-    // case insensitive ascending sort for function names
-    $left = strtoupper($a["fn"]);
-    $right = strtoupper($b["fn"]);
+        if ($left == $right) {
+            return 0;
+        }
+        return ($left < $right) ? -1 : 1;
+    } else {
+        // descending sort for all others
+        $left = $a[$sort_col];
+        $right = $b[$sort_col];
 
-    if ($left == $right)
-      return 0;
-    return ($left < $right) ? -1 : 1;
+        // if diff mode, sort by absolute value of regression/improvement
+        if ($diff_mode) {
+            $left = abs($left);
+            $right = abs($right);
+        }
 
-  } else {
-
-    // descending sort for all others
-    $left = $a[$sort_col];
-    $right = $b[$sort_col];
-
-    // if diff mode, sort by absolute value of regression/improvement
-    if ($diff_mode) {
-      $left = abs($left);
-      $right = abs($right);
+        if ($left == $right) {
+            return 0;
+        }
+        return ($left > $right) ? -1 : 1;
     }
-
-    if ($left == $right)
-      return 0;
-    return ($left > $right) ? -1 : 1;
-  }
 }
 
 /**
@@ -419,74 +432,74 @@ function sort_cbk($a, $b)
  *
  * @author Kannan
  */
-function init_metrics($xhprof_data, $rep_symbol, $sort, $diff_report = false) {
-  global $stats;
-  global $pc_stats;
-  global $metrics;
-  global $diff_mode;
-  global $sortable_columns;
-  global $sort_col;
-  global $display_calls;
+function init_metrics($xhprof_data, $rep_symbol, $sort, $diff_report = false)
+{
+    global $stats;
+    global $pc_stats;
+    global $metrics;
+    global $diff_mode;
+    global $sortable_columns;
+    global $sort_col;
+    global $display_calls;
 
-  $diff_mode = $diff_report;
+    $diff_mode = $diff_report;
 
-  if (!empty($sort)) {
-    if (array_key_exists($sort, $sortable_columns)) {
-      $sort_col = $sort;
-    } else {
-      print("Invalid Sort Key $sort specified in URL");
+    if (!empty($sort)) {
+        if (array_key_exists($sort, $sortable_columns)) {
+            $sort_col = $sort;
+        } else {
+            print("Invalid Sort Key $sort specified in URL");
+        }
     }
-  }
 
   // For C++ profiler runs, walltime attribute isn't present.
   // In that case, use "samples" as the default sort column.
-  if (!isset($xhprof_data["main()"]["wt"])) {
+    if (!isset($xhprof_data["main()"]["wt"])) {
+        if ($sort_col == "wt") {
+            $sort_col = "samples";
+        }
 
-    if ($sort_col == "wt") {
-      $sort_col = "samples";
+        // C++ profiler data doesn't have call counts.
+        // ideally we should check to see if "ct" metric
+        // is present for "main()". But currently "ct"
+        // metric is artificially set to 1. So, relying
+        // on absence of "wt" metric instead.
+        $display_calls = false;
+    } else {
+        $display_calls = true;
     }
-
-    // C++ profiler data doesn't have call counts.
-    // ideally we should check to see if "ct" metric
-    // is present for "main()". But currently "ct"
-    // metric is artificially set to 1. So, relying
-    // on absence of "wt" metric instead.
-    $display_calls = false;
-  } else {
-    $display_calls = true;
-  }
 
   // parent/child report doesn't support exclusive times yet.
   // So, change sort hyperlinks to closest fit.
-  if (!empty($rep_symbol)) {
-    $sort_col = str_replace("excl_", "", $sort_col);
-  }
-
-  if ($display_calls) {
-    $stats = array("fn", "ct", "Calls%");
-  } else {
-    $stats = array("fn");
-  }
-
-  $pc_stats = $stats;
-
-  $possible_metrics = xhprof_get_possible_metrics($xhprof_data);
-  foreach ($possible_metrics as $metric => $desc) {
-    if (isset($xhprof_data["main()"][$metric])) {
-      $metrics[] = $metric;
-      // flat (top-level reports): we can compute
-      // exclusive metrics reports as well.
-      $stats[] = $metric;
-      $stats[] = "I" . $desc[0] . "%";
-      $stats[] = "excl_" . $metric;
-      $stats[] = "E" . $desc[0] . "%";
-
-      // parent/child report for a function: we can
-      // only breakdown inclusive times correctly.
-      $pc_stats[] = $metric;
-      $pc_stats[] = "I" . $desc[0] . "%";
+    if (!empty($rep_symbol)) {
+        $sort_col = str_replace("excl_", "", $sort_col);
     }
-  }
+
+    if ($display_calls) {
+        $stats = array("fn", "ct", "Calls%");
+    } else {
+        $stats = array("fn");
+    }
+
+    $pc_stats = $stats;
+
+    $possible_metrics = xhprof_get_possible_metrics($xhprof_data);
+    foreach ($possible_metrics as $metric => $desc) {
+        if (isset($xhprof_data["main()"][$metric])) {
+            $metrics[] = $metric;
+            // flat (top-level reports): we can compute
+            // exclusive metrics reports as well.
+            $stats[] = $metric;
+            $stats[] = "I" . $desc[0] . "%";
+            $stats[] = "excl_" . $metric;
+            $stats[] = "E" . $desc[0] . "%";
+
+            // parent/child report for a function: we can
+            // only breakdown inclusive times correctly.
+            $pc_stats[] = $metric;
+            $pc_stats[] = "I" . $desc[0] . "%";
+        }
+    }
 }
 
 /**
@@ -496,16 +509,17 @@ function init_metrics($xhprof_data, $rep_symbol, $sort, $diff_report = false) {
  *
  * @author Kannan
  */
-function stat_description($stat) {
-  global $descriptions;
-  global $diff_descriptions;
-  global $diff_mode;
+function stat_description($stat)
+{
+    global $descriptions;
+    global $diff_descriptions;
+    global $diff_mode;
 
-  if ($diff_mode) {
-    return $diff_descriptions[$stat];
-  } else {
-    return $descriptions[$stat];
-  }
+    if ($diff_mode) {
+        return $diff_descriptions[$stat];
+    } else {
+        return $descriptions[$stat];
+    }
 }
 
 
@@ -515,88 +529,107 @@ function stat_description($stat) {
  *
  * @author: Kannan
  */
-function profiler_report ($url_params,
-                          $rep_symbol,
-                          $sort,
-                          $run1,
-                          $run1_desc,
-                          $run1_data,
-                          $run2 = 0,
-                          $run2_desc = "",
-                          $run2_data = array()) {
-  global $totals;
-  global $totals_1;
-  global $totals_2;
-  global $stats;
-  global $pc_stats;
-  global $diff_mode;
-  global $base_path;
+function profiler_report(
+    $url_params,
+    $rep_symbol,
+    $sort,
+    $run1,
+    $run1_desc,
+    $run1_data,
+    $run2 = 0,
+    $run2_desc = "",
+    $run2_data = array()
+) {
+    global $totals;
+    global $totals_1;
+    global $totals_2;
+    global $stats;
+    global $pc_stats;
+    global $diff_mode;
+    global $base_path;
 
   // if we are reporting on a specific function, we can trim down
   // the report(s) to just stuff that is relevant to this function.
   // That way compute_flat_info()/compute_diff() etc. do not have
   // to needlessly work hard on churning irrelevant data.
-  if (!empty($rep_symbol)) {
-    $run1_data = xhprof_trim_run($run1_data, array($rep_symbol));
-    if ($diff_mode) {
-      $run2_data = xhprof_trim_run($run2_data, array($rep_symbol));
+    if (!empty($rep_symbol)) {
+        $run1_data = xhprof_trim_run($run1_data, array($rep_symbol));
+        if ($diff_mode) {
+            $run2_data = xhprof_trim_run($run2_data, array($rep_symbol));
+        }
     }
-  }
 
-  if ($diff_mode) {
-    $run_delta = xhprof_compute_diff($run1_data, $run2_data);
-    $symbol_tab  = xhprof_compute_flat_info($run_delta, $totals);
-    $symbol_tab1 = xhprof_compute_flat_info($run1_data, $totals_1);
-    $symbol_tab2 = xhprof_compute_flat_info($run2_data, $totals_2);
-  } else {
-    $symbol_tab = xhprof_compute_flat_info($run1_data, $totals);
-  }
+    if ($diff_mode) {
+        $run_delta = xhprof_compute_diff($run1_data, $run2_data);
+        $symbol_tab  = xhprof_compute_flat_info($run_delta, $totals);
+        $symbol_tab1 = xhprof_compute_flat_info($run1_data, $totals_1);
+        $symbol_tab2 = xhprof_compute_flat_info($run2_data, $totals_2);
+    } else {
+        $symbol_tab = xhprof_compute_flat_info($run1_data, $totals);
+    }
 
-  $run1_txt = sprintf("<b>Run #%s:</b> %s", $run1, $run1_desc);
+    $run1_txt = sprintf("<b>Run #%s:</b> %s", $run1, $run1_desc);
 
-  $base_url_params = xhprof_array_unset(xhprof_array_unset($url_params,
-                                                           'symbol'),
-                                        'all');
+    $base_url_params = xhprof_array_unset(
+        xhprof_array_unset(
+            $url_params,
+            'symbol'
+        ),
+        'all'
+    );
 
-  $top_link_query_string = "$base_path/?" . http_build_query($base_url_params);
+    $top_link_query_string = "$base_path/?" . http_build_query($base_url_params);
 
-  if ($diff_mode) {
-    $diff_text = "Diff";
-    $base_url_params = xhprof_array_unset($base_url_params, 'run1');
-    $base_url_params = xhprof_array_unset($base_url_params, 'run2');
-    $run1_link = xhprof_render_link('View Run #' . $run1,
-                           "$base_path/?" .
-                           http_build_query(xhprof_array_set($base_url_params,
-                                                      'run',
-                                                      $run1)));
-    $run2_txt = sprintf("<b>Run #%s:</b> %s",
-                        $run2, $run2_desc);
+    if ($diff_mode) {
+        $diff_text = "Diff";
+        $base_url_params = xhprof_array_unset($base_url_params, 'run1');
+        $base_url_params = xhprof_array_unset($base_url_params, 'run2');
+        $run1_link = xhprof_render_link(
+            'View Run #' . $run1,
+            "$base_path/?" .
+                           http_build_query(xhprof_array_set(
+                               $base_url_params,
+                               'run',
+                               $run1
+                           ))
+        );
+        $run2_txt = sprintf(
+            "<b>Run #%s:</b> %s",
+            $run2,
+            $run2_desc
+        );
 
-    $run2_link = xhprof_render_link('View Run #' . $run2,
-                                    "$base_path/?" .
-                        http_build_query(xhprof_array_set($base_url_params,
-                                                          'run',
-                                                          $run2)));
-  } else {
-    $diff_text = "Run";
-  }
+        $run2_link = xhprof_render_link(
+            'View Run #' . $run2,
+            "$base_path/?" .
+                        http_build_query(xhprof_array_set(
+                            $base_url_params,
+                            'run',
+                            $run2
+                        ))
+        );
+    } else {
+        $diff_text = "Run";
+    }
 
   // set up the action links for operations that can be done on this report
-  $links = array();
+    $links = array();
 
 
-  if ($diff_mode) {
-    $inverted_params = $url_params;
-    $inverted_params['run1'] = $url_params['run2'];
-    $inverted_params['run2'] = $url_params['run1'];
+    if ($diff_mode) {
+        $inverted_params = $url_params;
+        $inverted_params['run1'] = $url_params['run2'];
+        $inverted_params['run2'] = $url_params['run1'];
 
-    // view the different runs or invert the current diff
-    $links []= $run1_link;
-    $links []= $run2_link;
-    $links []= xhprof_render_link('Invert ' . $diff_text . ' Report',
-                           "$base_path/?".
-                           http_build_query($inverted_params));
-  }
+        // view the different runs or invert the current diff
+        $links []= $run1_link;
+        $links []= $run2_link;
+        $links []= xhprof_render_link(
+            'Invert ' . $diff_text . ' Report',
+            "$base_path/?".
+            http_build_query($inverted_params)
+        );
+    }
 
   // lookup function typeahead form
 
@@ -616,44 +649,57 @@ function profiler_report ($url_params,
     '<div style="clear: both; margin: 3em 0em;"></div>';
 */
   // data tables
-  if (!empty($rep_symbol)) {
-    if (!isset($symbol_tab[$rep_symbol])) {
-      echo "<hr>Symbol <b>$rep_symbol</b> not found in XHProf run</b><hr>";
-      return;
-    }
+    if (!empty($rep_symbol)) {
+        if (!isset($symbol_tab[$rep_symbol])) {
+            echo "<hr>Symbol <b>$rep_symbol</b> not found in XHProf run</b><hr>";
+            return;
+        }
 
-    /* single function report with parent/child information */
-    if ($diff_mode) {
-      $info1 = isset($symbol_tab1[$rep_symbol]) ?
+        /* single function report with parent/child information */
+        if ($diff_mode) {
+            $info1 = isset($symbol_tab1[$rep_symbol]) ?
                        $symbol_tab1[$rep_symbol] : null;
-      $info2 = isset($symbol_tab2[$rep_symbol]) ?
+            $info2 = isset($symbol_tab2[$rep_symbol]) ?
                        $symbol_tab2[$rep_symbol] : null;
-      symbol_report($url_params, $run_delta, $symbol_tab[$rep_symbol],
-                    $sort, $rep_symbol,
-                    $run1, $info1,
-                    $run2, $info2);
+            symbol_report(
+                $url_params,
+                $run_delta,
+                $symbol_tab[$rep_symbol],
+                $sort,
+                $rep_symbol,
+                $run1,
+                $info1,
+                $run2,
+                $info2
+            );
+        } else {
+            symbol_report(
+                $url_params,
+                $run1_data,
+                $symbol_tab[$rep_symbol],
+                $sort,
+                $rep_symbol,
+                $run1
+            );
+        }
     } else {
-      symbol_report($url_params, $run1_data, $symbol_tab[$rep_symbol],
-                    $sort, $rep_symbol, $run1);
+        /* flat top-level report of all functions */
+        full_report($url_params, $symbol_tab, $sort, $run1, $run2, $links);
     }
-  } else {
-    /* flat top-level report of all functions */
-    full_report($url_params, $symbol_tab, $sort, $run1, $run2, $links);
-  }
-
 }
 
 /**
  * Computes percentage for a pair of values, and returns it
  * in string format.
  */
-function pct($a, $b) {
-  if ($b == 0) {
-    return "N/A";
-  } else {
-    $res = (round(($a * 1000 / $b)) / 10);
-    return $res;
-  }
+function pct($a, $b)
+{
+    if ($b == 0) {
+        return "N/A";
+    } else {
+        $res = (round(($a * 1000 / $b)) / 10);
+        return $res;
+    }
 }
 
 /**
@@ -663,62 +709,64 @@ function pct($a, $b) {
  * represent improvement from run1 to run2. We use green to display those deltas,
  * and red for regression deltas.
  */
-function get_print_class($num, $bold) {
-  global $vbar;
-  global $vbbar;
-  global $vrbar;
-  global $vgbar;
-  global $diff_mode;
+function get_print_class($num, $bold)
+{
+    global $vbar;
+    global $vbbar;
+    global $vrbar;
+    global $vgbar;
+    global $diff_mode;
 
-  if ($bold) {
-    if ($diff_mode) {
-      if ($num <= 0) {
-        $class = $vgbar; // green (improvement)
-      } else {
-        $class = $vrbar; // red (regression)
-      }
+    if ($bold) {
+        if ($diff_mode) {
+            if ($num <= 0) {
+                $class = $vgbar; // green (improvement)
+            } else {
+                $class = $vrbar; // red (regression)
+            }
+        } else {
+            $class = $vbbar; // blue
+        }
     } else {
-      $class = $vbbar; // blue
+        $class = $vbar;  // default (black)
     }
-  }
-  else {
-    $class = $vbar;  // default (black)
-  }
 
-  return $class;
+    return $class;
 }
 
 /**
  * Prints a <td> element with a numeric value.
  */
-function print_td_num($num, $fmt_func, $bold=false, $attributes=null) {
+function print_td_num($num, $fmt_func, $bold = false, $attributes = null)
+{
 
-  $class = get_print_class($num, $bold);
+    $class = get_print_class($num, $bold);
 
-  if (!empty($fmt_func)) {
-    $num = call_user_func($fmt_func, $num);
-  }
+    if (!empty($fmt_func)) {
+        $num = call_user_func($fmt_func, $num);
+    }
 
-  print("<td $attributes $class>$num</td>\n");
+    print("<td $attributes $class>$num</td>\n");
 }
 
 /**
  * Prints a <td> element with a pecentage.
  */
-function print_td_pct($numer, $denom, $bold=false, $attributes=null) {
-  global $vbar;
-  global $vbbar;
-  global $diff_mode;
+function print_td_pct($numer, $denom, $bold = false, $attributes = null)
+{
+    global $vbar;
+    global $vbbar;
+    global $diff_mode;
 
-  $class = get_print_class($numer, $bold);
+    $class = get_print_class($numer, $bold);
 
-  if ($denom == 0) {
-    $pct = "N/A%";
-  } else {
-    $pct = xhprof_percent_format($numer / abs($denom));
-  }
+    if ($denom == 0) {
+        $pct = "N/A%";
+    } else {
+        $pct = xhprof_percent_format($numer / abs($denom));
+    }
 
-  print("<td $attributes $class>$pct</td>\n");
+    print("<td $attributes $class>$pct</td>\n");
 }
 
 /**
@@ -726,58 +774,71 @@ function print_td_pct($numer, $denom, $bold=false, $attributes=null) {
  *
  * @author Kannan
  */
-function print_function_info($url_params, $info, $sort, $run1, $run2) {
-  static $odd_even = 0;
+function print_function_info($url_params, $info, $sort, $run1, $run2)
+{
+    static $odd_even = 0;
 
-  global $totals;
-  global $sort_col;
-  global $metrics;
-  global $format_cbk;
-  global $display_calls;
-  global $base_path;
+    global $totals;
+    global $sort_col;
+    global $metrics;
+    global $format_cbk;
+    global $display_calls;
+    global $base_path;
 
   // Toggle $odd_or_even
-  $odd_even = 1 - $odd_even;
+    $odd_even = 1 - $odd_even;
 
-  if ($odd_even) {
-    print("<tr>");
-  }
-  else {
-    print('<tr>');
-  }
+    if ($odd_even) {
+        print("<tr>");
+    } else {
+        print('<tr>');
+    }
 
-  $href = "$base_path/?" .
-           http_build_query(xhprof_array_set($url_params,
-                                             'symbol', $info["fn"]));
+    $href = "$base_path/?" .
+           http_build_query(xhprof_array_set(
+               $url_params,
+               'symbol',
+               $info["fn"]
+           ));
 
-  print('<td>');
-  print(xhprof_render_link($info["fn"], $href));
-  print("</td>\n");
+    print('<td>');
+    print(xhprof_render_link($info["fn"], $href));
+    print("</td>\n");
 
-  if ($display_calls) {
-    // Call Count..
-    print_td_num($info["ct"], $format_cbk["ct"], ($sort_col == "ct"));
-    print_td_pct($info["ct"], $totals["ct"], ($sort_col == "ct"));
-  }
+    if ($display_calls) {
+        // Call Count..
+        print_td_num($info["ct"], $format_cbk["ct"], ($sort_col == "ct"));
+        print_td_pct($info["ct"], $totals["ct"], ($sort_col == "ct"));
+    }
 
   // Other metrics..
-  foreach ($metrics as $metric) {
-    // Inclusive metric
-    print_td_num($info[$metric], $format_cbk[$metric],
-                 ($sort_col == $metric));
-    print_td_pct($info[$metric], $totals[$metric],
-                 ($sort_col == $metric));
+    foreach ($metrics as $metric) {
+        // Inclusive metric
+        print_td_num(
+            $info[$metric],
+            $format_cbk[$metric],
+            ($sort_col == $metric)
+        );
+        print_td_pct(
+            $info[$metric],
+            $totals[$metric],
+            ($sort_col == $metric)
+        );
 
-    // Exclusive Metric
-    print_td_num($info["excl_" . $metric],
-                 $format_cbk["excl_" . $metric],
-                 ($sort_col == "excl_" . $metric));
-    print_td_pct($info["excl_" . $metric],
-                 $totals[$metric],
-                 ($sort_col == "excl_" . $metric));
-  }
+        // Exclusive Metric
+        print_td_num(
+            $info["excl_" . $metric],
+            $format_cbk["excl_" . $metric],
+            ($sort_col == "excl_" . $metric)
+        );
+        print_td_pct(
+            $info["excl_" . $metric],
+            $totals[$metric],
+            ($sort_col == "excl_" . $metric)
+        );
+    }
 
-  print("</tr>\n");
+    print("</tr>\n");
 }
 
 /**
@@ -785,54 +846,55 @@ function print_function_info($url_params, $info, $sort, $run1, $run2) {
  *
  * @author Kannan
  */
-function print_flat_data($url_params, $title, $flat_data, $sort, $run1, $run2, $limit) {
+function print_flat_data($url_params, $title, $flat_data, $sort, $run1, $run2, $limit)
+{
 
-  global $stats;
-  global $sortable_columns;
-  global $vwbar;
-  global $base_path;
+    global $stats;
+    global $sortable_columns;
+    global $vwbar;
+    global $base_path;
 
-  $size  = count($flat_data);
-  if (!$limit) {              // no limit
-    $limit = $size;
-    $display_link = "";
-  } else {
-    $display_link = xhprof_render_link(" [ <b class=bubble>display all </b>]",
-                                       "$base_path/?" .
-                                       http_build_query(xhprof_array_set($url_params,
-                                                                         'all', 1)));
-  }
+    $size  = count($flat_data);
+    if (!$limit) {              // no limit
+        $limit = $size;
+        $display_link = "";
+    } else {
+        $display_link = xhprof_render_link(
+            " [ <b class=bubble>display all </b>]",
+            "$base_path/?" .
+                                       http_build_query(xhprof_array_set(
+                                           $url_params,
+                                           'all',
+                                           1
+                                       ))
+        );
+    }
 
   //Find top $n requests
-  $data_copy = $flat_data;
-  $data_copy = _aggregateCalls($data_copy, null, $run2);
-  usort($data_copy, 'sortWT');
+    $data_copy = $flat_data;
+    $data_copy = _aggregateCalls($data_copy, null, $run2);
+    usort($data_copy, 'sortWT');
 
-  $iterations = 0;
-  $colors = array('#4572A7', '#AA4643', '#89A54E', '#80699B', '#3D96AE', '#DB843D', '#92A8CD', '#A47D7C', '#B5CA92', '#EAFEBB', '#FEB4B1', '#2B6979', '#E9D6FE', '#FECDA3', '#FED980');
-  foreach($data_copy as $datapoint)
-  {
-    if (++$iterations > 14)
-    {
-        $function_color[$datapoint['fn']] = $colors[14];
-    }else
-    {
-        $function_color[$datapoint['fn']] = $colors[$iterations-1];
+    $iterations = 0;
+    $colors = array('#4572A7', '#AA4643', '#89A54E', '#80699B', '#3D96AE', '#DB843D', '#92A8CD', '#A47D7C', '#B5CA92', '#EAFEBB', '#FEB4B1', '#2B6979', '#E9D6FE', '#FECDA3', '#FED980');
+    foreach ($data_copy as $datapoint) {
+        if (++$iterations > 14) {
+            $function_color[$datapoint['fn']] = $colors[14];
+        } else {
+            $function_color[$datapoint['fn']] = $colors[$iterations-1];
+        }
     }
-  }
 
-  include( "../xhprof_lib/templates/profChart.phtml");
-  include( "../xhprof_lib/templates/profTable.phtml");
-
+    include("../xhprof_lib/templates/profChart.phtml");
+    include("../xhprof_lib/templates/profTable.phtml");
 }
 
 function sortWT($a, $b)
 {
-  if ($a['excl_wt'] == $b['excl_wt'])
-  {
-    return 0;
-  }
-  return ($a['excl_wt'] < $b['excl_wt']) ? 1 : -1;
+    if ($a['excl_wt'] == $b['excl_wt']) {
+        return 0;
+    }
+    return ($a['excl_wt'] < $b['excl_wt']) ? 1 : -1;
 }
 
 /**
@@ -840,81 +902,82 @@ function sortWT($a, $b)
  *
  * @author Kannan
  */
-function full_report($url_params, $symbol_tab, $sort, $run1, $run2, $links) {
-  global $vwbar;
-  global $vbar;
-  global $totals;
-  global $totals_1;
-  global $totals_2;
-  global $metrics;
-  global $diff_mode;
-  global $descriptions;
-  global $sort_col;
-  global $format_cbk;
-  global $display_calls;
-  global $base_path;
+function full_report($url_params, $symbol_tab, $sort, $run1, $run2, $links)
+{
+    global $vwbar;
+    global $vbar;
+    global $totals;
+    global $totals_1;
+    global $totals_2;
+    global $metrics;
+    global $diff_mode;
+    global $descriptions;
+    global $sort_col;
+    global $format_cbk;
+    global $display_calls;
+    global $base_path;
 
-  $possible_metrics = xhprof_get_possible_metrics();
+    $possible_metrics = xhprof_get_possible_metrics();
 
-  if ($diff_mode) {
-      global $xhprof_runs_impl;
-      include "../xhprof_lib/templates/diff_run_header_block.phtml";
-
-  } else {
-      global $xhprof_runs_impl;
-    include "../xhprof_lib/templates/single_run_header_block.phtml";
-  }
+    if ($diff_mode) {
+        global $xhprof_runs_impl;
+        include "../xhprof_lib/templates/diff_run_header_block.phtml";
+    } else {
+        global $xhprof_runs_impl;
+        include "../xhprof_lib/templates/single_run_header_block.phtml";
+    }
 
 
   //echo xhprof_render_actions($links);
 
 
-  $flat_data = array();
-  foreach ($symbol_tab as $symbol => $info) {
-    $tmp = $info;
-    $tmp["fn"] = $symbol;
+    $flat_data = array();
+    foreach ($symbol_tab as $symbol => $info) {
+        $tmp = $info;
+        $tmp["fn"] = $symbol;
 
-    $flat_data[] = $tmp;
-  }
-  usort($flat_data, 'sort_cbk');
+        $flat_data[] = $tmp;
+    }
+    usort($flat_data, 'sort_cbk');
 
-  print("<br />");
+    print("<br />");
 
-  if (!empty($url_params['all'])) {
-    $all = true;
-    $limit = 0;    // display all rows
-  } else {
-    $all = false;
-    $limit = 100;  // display only limited number of rows
-  }
-
-  $desc = str_replace("<br />", " ", $descriptions[$sort_col]);
-
-  if ($diff_mode) {
-    if ($all) {
-      $title = "Total Diff Report: '
-               .'Sorted by absolute value of regression/improvement in $desc";
+    if (!empty($url_params['all'])) {
+        $all = true;
+        $limit = 0;    // display all rows
     } else {
-      $title = "Top 100 <i style='color:red'>Regressions</i>/"
+        $all = false;
+        $limit = 100;  // display only limited number of rows
+    }
+
+    $desc = str_replace("<br />", " ", $descriptions[$sort_col]);
+
+    if ($diff_mode) {
+        if ($all) {
+            $title = "Total Diff Report: '
+               .'Sorted by absolute value of regression/improvement in $desc";
+        } else {
+            $title = "Top 100 <i style='color:red'>Regressions</i>/"
                . "<i style='color:green'>Improvements</i>: "
                . "Sorted by $desc Diff";
-    }
-  } else {
-    if ($all) {
-      $title = "Sorted by $desc";
+        }
     } else {
-      $title = "Displaying top $limit functions: Sorted by $desc";
+        if ($all) {
+            $title = "Sorted by $desc";
+        } else {
+            $title = "Displaying top $limit functions: Sorted by $desc";
+        }
     }
-  }
-  print_flat_data($url_params, $title, $flat_data, $sort, $run1, $run2, $limit);
+    print_flat_data($url_params, $title, $flat_data, $sort, $run1, $run2, $limit);
 }
 
 
 /**
  * Return attribute names and values to be used by javascript tooltip.
  */
-function get_tooltip_attributes($type, $metric) {
-  return "type='$type' metric='$metric'";
+function get_tooltip_attributes($type, $metric)
+{
+    return "type='$type' metric='$metric'";
 }
 
 /**
@@ -923,87 +986,105 @@ function get_tooltip_attributes($type, $metric) {
  *
  * @author Kannan
  */
-function pc_info($info, $base_ct, $base_info, $parent) {
-  global $sort_col;
-  global $metrics;
-  global $format_cbk;
-  global $display_calls;
+function pc_info($info, $base_ct, $base_info, $parent)
+{
+    global $sort_col;
+    global $metrics;
+    global $format_cbk;
+    global $display_calls;
 
-  if ($parent)
-    $type = "Parent";
-  else
-    $type = "Child";
+    if ($parent) {
+        $type = "Parent";
+    } else {
+        $type = "Child";
+    }
 
-  if ($display_calls) {
-    $mouseoverct = get_tooltip_attributes($type, "ct");
-    /* call count */
-    print_td_num($info["ct"], $format_cbk["ct"], ($sort_col == "ct"), $mouseoverct);
-    print_td_pct($info["ct"], $base_ct, ($sort_col == "ct"), $mouseoverct);
-  }
+    if ($display_calls) {
+        $mouseoverct = get_tooltip_attributes($type, "ct");
+        /* call count */
+        print_td_num($info["ct"], $format_cbk["ct"], ($sort_col == "ct"), $mouseoverct);
+        print_td_pct($info["ct"], $base_ct, ($sort_col == "ct"), $mouseoverct);
+    }
 
   /* Inclusive metric values  */
-  foreach ($metrics as $metric) {
-    print_td_num($info[$metric], $format_cbk[$metric],
-                 ($sort_col == $metric),
-                 get_tooltip_attributes($type, $metric));
-    print_td_pct($info[$metric], $base_info[$metric], ($sort_col == $metric),
-                 get_tooltip_attributes($type, $metric));
-  }
+    foreach ($metrics as $metric) {
+        print_td_num(
+            $info[$metric],
+            $format_cbk[$metric],
+            ($sort_col == $metric),
+            get_tooltip_attributes($type, $metric)
+        );
+        print_td_pct(
+            $info[$metric],
+            $base_info[$metric],
+            ($sort_col == $metric),
+            get_tooltip_attributes($type, $metric)
+        );
+    }
 }
 
-function print_pc_array($url_params, $results, $base_ct, $base_info, $parent,
-                        $run1, $run2) {
-  global $base_path;
+function print_pc_array(
+    $url_params,
+    $results,
+    $base_ct,
+    $base_info,
+    $parent,
+    $run1,
+    $run2
+) {
+    global $base_path;
 
   // Construct section title
-  if ($parent) {
-    $title = 'Parent function';
-  }
-  else {
-    $title = 'Child function';
-  }
-  if (count($results) > 1) {
-    $title .= 's';
-  }
-
-  print("<tr class='box-table-title'><td>");
-  print("<strong>" . $title . "</strong>");
-  print("</td></tr>");
-
-  $odd_even = 0;
-  foreach ($results as $info) {
-    $href = "$base_path/?" .
-      http_build_query(xhprof_array_set($url_params,
-                                        'symbol', $info["fn"]));
-    $odd_even = 1 - $odd_even;
-
-    if ($odd_even) {
-      print('<tr>');
+    if ($parent) {
+        $title = 'Parent function';
+    } else {
+        $title = 'Child function';
     }
-    else {
-      print('<tr>');
+    if (count($results) > 1) {
+        $title .= 's';
     }
 
-    print("<td>" . xhprof_render_link($info["fn"], $href) . "</td>");
-    pc_info($info, $base_ct, $base_info, $parent);
-    print("</tr>");
-  }
+    print("<tr class='box-table-title'><td>");
+    print("<strong>" . $title . "</strong>");
+    print("</td></tr>");
+
+    $odd_even = 0;
+    foreach ($results as $info) {
+        $href = "$base_path/?" .
+        http_build_query(xhprof_array_set(
+            $url_params,
+            'symbol',
+            $info["fn"]
+        ));
+        $odd_even = 1 - $odd_even;
+
+        if ($odd_even) {
+              print('<tr>');
+        } else {
+              print('<tr>');
+        }
+
+        print("<td>" . xhprof_render_link($info["fn"], $href) . "</td>");
+        pc_info($info, $base_ct, $base_info, $parent);
+        print("</tr>");
+    }
 }
 
 
-function print_symbol_summary($symbol_info, $stat, $base) {
+function print_symbol_summary($symbol_info, $stat, $base)
+{
 
-  $val = $symbol_info[$stat];
-  $desc = str_replace("<br />", " ", stat_description($stat));
+    $val = $symbol_info[$stat];
+    $desc = str_replace("<br />", " ", stat_description($stat));
 
-  print("$desc: </td>");
-  print(number_format($val));
-  print(" (" . pct($val, $base) . "% of overall)");
-  if (substr($stat, 0, 4) == "excl") {
-    $func_base = $symbol_info[str_replace("excl_", "", $stat)];
-    print(" (" . pct($val, $func_base) . "% of this function)");
-  }
-  print("<br />");
+    print("$desc: </td>");
+    print(number_format($val));
+    print(" (" . pct($val, $base) . "% of overall)");
+    if (substr($stat, 0, 4) == "excl") {
+        $func_base = $symbol_info[str_replace("excl_", "", $stat)];
+        print(" (" . pct($val, $func_base) . "% of this function)");
+    }
+    print("<br />");
 }
 
 /**
@@ -1011,264 +1092,300 @@ function print_symbol_summary($symbol_info, $stat, $base) {
  *
  * @author Kannan
  */
-function symbol_report($url_params,
-                       $run_data, $symbol_info, $sort, $rep_symbol,
-                       $run1,
-                       $symbol_info1 = null,
-                       $run2 = 0,
-                       $symbol_info2 = null) {
-  global $vwbar;
-  global $vbar;
-  global $totals;
-  global $pc_stats;
-  global $sortable_columns;
-  global $metrics;
-  global $diff_mode;
-  global $descriptions;
-  global $format_cbk;
-  global $sort_col;
-  global $display_calls;
-  global $base_path;
+function symbol_report(
+    $url_params,
+    $run_data,
+    $symbol_info,
+    $sort,
+    $rep_symbol,
+    $run1,
+    $symbol_info1 = null,
+    $run2 = 0,
+    $symbol_info2 = null
+) {
+    global $vwbar;
+    global $vbar;
+    global $totals;
+    global $pc_stats;
+    global $sortable_columns;
+    global $metrics;
+    global $diff_mode;
+    global $descriptions;
+    global $format_cbk;
+    global $sort_col;
+    global $display_calls;
+    global $base_path;
 
-  $possible_metrics = xhprof_get_possible_metrics();
+    $possible_metrics = xhprof_get_possible_metrics();
 
-  if ($diff_mode) {
-    $diff_text = "<b>Diff</b>";
-    $regr_impr = "<i style='color:red'>Regression</i>/<i style='color:green'>Improvement</i>";
-  } else {
-    $diff_text = "";
-    $regr_impr = "";
-  }
+    if ($diff_mode) {
+        $diff_text = "<b>Diff</b>";
+        $regr_impr = "<i style='color:red'>Regression</i>/<i style='color:green'>Improvement</i>";
+    } else {
+        $diff_text = "";
+        $regr_impr = "";
+    }
 
-  if ($diff_mode) {
+    if ($diff_mode) {
+        $base_url_params = xhprof_array_unset(
+            xhprof_array_unset(
+                $url_params,
+                'run1'
+            ),
+            'run2'
+        );
+        $href1 = "$base_path?"
+          . http_build_query(xhprof_array_set($base_url_params, 'run', $run1));
+        $href2 = "$base_path?"
+          . http_build_query(xhprof_array_set($base_url_params, 'run', $run2));
 
-    $base_url_params = xhprof_array_unset(xhprof_array_unset($url_params,
-                                                             'run1'),
-                                          'run2');
-    $href1 = "$base_path?"
-      . http_build_query(xhprof_array_set($base_url_params, 'run', $run1));
-    $href2 = "$base_path?"
-      . http_build_query(xhprof_array_set($base_url_params, 'run', $run2));
-
-    print("<h3 align=center>$regr_impr summary for $rep_symbol<br /><br /></h3>");
-    print('<table cellpadding=2 cellspacing=1 width="30%" '
+        print("<h3 align=center>$regr_impr summary for $rep_symbol<br /><br /></h3>");
+        print('<table cellpadding=2 cellspacing=1 width="30%" '
           .'rules=rows align=center>' . "\n");
-    print('<tr align=right>');
-    print("<th align=left>$rep_symbol</th>");
-    print("<th $vwbar><a href=" . $href1 . ">Run #$run1</a></th>");
-    print("<th $vwbar><a href=" . $href2 . ">Run #$run2</a></th>");
-    print("<th $vwbar>Diff</th>");
-    print("<th $vwbar>Diff%</th>");
-    print('</tr>');
-    print('<tr>');
+        print('<tr align=right>');
+        print("<th align=left>$rep_symbol</th>");
+        print("<th $vwbar><a href=" . $href1 . ">Run #$run1</a></th>");
+        print("<th $vwbar><a href=" . $href2 . ">Run #$run2</a></th>");
+        print("<th $vwbar>Diff</th>");
+        print("<th $vwbar>Diff%</th>");
+        print('</tr>');
+        print('<tr>');
 
-    if ($display_calls) {
-      print("<td>Number of Function Calls</td>");
-      print_td_num($symbol_info1["ct"], $format_cbk["ct"]);
-      print_td_num($symbol_info2["ct"], $format_cbk["ct"]);
-      print_td_num($symbol_info2["ct"] - $symbol_info1["ct"],
-                   $format_cbk["ct"], true);
-      print_td_pct($symbol_info2["ct"] - $symbol_info1["ct"],
-                   $symbol_info1["ct"], true);
-      print('</tr>');
+        if ($display_calls) {
+              print("<td>Number of Function Calls</td>");
+              print_td_num($symbol_info1["ct"], $format_cbk["ct"]);
+              print_td_num($symbol_info2["ct"], $format_cbk["ct"]);
+              print_td_num(
+                  $symbol_info2["ct"] - $symbol_info1["ct"],
+                  $format_cbk["ct"],
+                  true
+              );
+              print_td_pct(
+                  $symbol_info2["ct"] - $symbol_info1["ct"],
+                  $symbol_info1["ct"],
+                  true
+              );
+              print('</tr>');
+        }
+
+
+        foreach ($metrics as $metric) {
+              $m = $metric;
+
+              // Inclusive stat for metric
+              print('<tr>');
+              print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . "</td>");
+              print_td_num($symbol_info1[$m], $format_cbk[$m]);
+              print_td_num($symbol_info2[$m], $format_cbk[$m]);
+              print_td_num($symbol_info2[$m] - $symbol_info1[$m], $format_cbk[$m], true);
+              print_td_pct($symbol_info2[$m] - $symbol_info1[$m], $symbol_info1[$m], true);
+              print('</tr>');
+
+              // AVG (per call) Inclusive stat for metric
+              print('<tr>');
+              print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . " per call </td>");
+              $avg_info1 = 'N/A';
+              $avg_info2 = 'N/A';
+            if ($symbol_info1['ct'] > 0) {
+                $avg_info1 = ($symbol_info1[$m]/$symbol_info1['ct']);
+            }
+            if ($symbol_info2['ct'] > 0) {
+                $avg_info2 = ($symbol_info2[$m]/$symbol_info2['ct']);
+            }
+              print_td_num($avg_info1, $format_cbk[$m]);
+              print_td_num($avg_info2, $format_cbk[$m]);
+              print_td_num($avg_info2 - $avg_info1, $format_cbk[$m], true);
+              print_td_pct($avg_info2 - $avg_info1, $avg_info1, true);
+              print('</tr>');
+
+              // Exclusive stat for metric
+              $m = "excl_" . $metric;
+              print('<tr>');
+              print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . "</td>");
+              print_td_num($symbol_info1[$m], $format_cbk[$m]);
+              print_td_num($symbol_info2[$m], $format_cbk[$m]);
+              print_td_num($symbol_info2[$m] - $symbol_info1[$m], $format_cbk[$m], true);
+              print_td_pct($symbol_info2[$m] - $symbol_info1[$m], $symbol_info1[$m], true);
+              print('</tr>');
+        }
+
+        print('</table>');
     }
 
+    print("<br /><h1 class='runTitle'>");
+    print("Parent/Child $regr_impr report for <b>$rep_symbol</b></h1>");
 
-    foreach ($metrics as $metric) {
-      $m = $metric;
-
-      // Inclusive stat for metric
-      print('<tr>');
-      print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . "</td>");
-      print_td_num($symbol_info1[$m], $format_cbk[$m]);
-      print_td_num($symbol_info2[$m], $format_cbk[$m]);
-      print_td_num($symbol_info2[$m] - $symbol_info1[$m], $format_cbk[$m], true);
-      print_td_pct($symbol_info2[$m] - $symbol_info1[$m], $symbol_info1[$m], true);
-      print('</tr>');
-
-      // AVG (per call) Inclusive stat for metric
-      print('<tr>');
-      print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . " per call </td>");
-      $avg_info1 = 'N/A';
-      $avg_info2 = 'N/A';
-      if ($symbol_info1['ct'] > 0) {
-        $avg_info1 = ($symbol_info1[$m]/$symbol_info1['ct']);
-      }
-      if ($symbol_info2['ct'] > 0) {
-        $avg_info2 = ($symbol_info2[$m]/$symbol_info2['ct']);
-      }
-      print_td_num($avg_info1, $format_cbk[$m]);
-      print_td_num($avg_info2, $format_cbk[$m]);
-      print_td_num($avg_info2 - $avg_info1, $format_cbk[$m], true);
-      print_td_pct($avg_info2 - $avg_info1, $avg_info1, true);
-      print('</tr>');
-
-      // Exclusive stat for metric
-      $m = "excl_" . $metric;
-      print('<tr>');
-      print("<td>" . str_replace("<br />", " ", $descriptions[$m]) . "</td>");
-      print_td_num($symbol_info1[$m], $format_cbk[$m]);
-      print_td_num($symbol_info2[$m], $format_cbk[$m]);
-      print_td_num($symbol_info2[$m] - $symbol_info1[$m], $format_cbk[$m], true);
-      print_td_pct($symbol_info2[$m] - $symbol_info1[$m], $symbol_info1[$m], true);
-      print('</tr>');
-    }
-
-    print('</table>');
-  }
-
-  print("<br /><h1 class='runTitle'>");
-  print("Parent/Child $regr_impr report for <b>$rep_symbol</b></h1>");
-
-  $callgraph_href = "$base_path/callgraph.php?"
+    $callgraph_href = "$base_path/callgraph.php?"
     . http_build_query(xhprof_array_set($url_params, 'func', $rep_symbol));
 
-  print(" <a class='callgraph' href='$callgraph_href'>View Callgraph $diff_text</a><br />");
+    print(" <a class='callgraph' href='$callgraph_href'>View Callgraph $diff_text</a><br />");
 
-  print("<br />");
+    print("<br />");
 
-  print('<table class="box-tables" border=1 cellpadding=2 cellspacing=1 width="90%" '
+    print('<table class="box-tables" border=1 cellpadding=2 cellspacing=1 width="90%" '
         .'rules=rows align=center>' . "\n");
-  print('<tr align=right>');
+    print('<tr align=right>');
 
-  foreach ($pc_stats as $stat) {
-    $desc = stat_description($stat);
-    if (array_key_exists($stat, $sortable_columns)) {
+    foreach ($pc_stats as $stat) {
+        $desc = stat_description($stat);
+        if (array_key_exists($stat, $sortable_columns)) {
+            $href = "$base_path/?" .
+            http_build_query(xhprof_array_set(
+                $url_params,
+                'sort',
+                $stat
+            ));
+            $header = xhprof_render_link($desc, $href);
+        } else {
+            $header = $desc;
+        }
 
-      $href = "$base_path/?" .
-        http_build_query(xhprof_array_set($url_params,
-                                          'sort', $stat));
-      $header = xhprof_render_link($desc, $href);
-    } else {
-      $header = $desc;
+        if ($stat == "fn") {
+            print("<th align=left><nobr>$header</th>");
+        } else {
+            print("<th " . $vwbar . "><nobr>$header</th>");
+        }
     }
+    print("</tr>");
 
-    if ($stat == "fn")
-      print("<th align=left><nobr>$header</th>");
-    else
-      print("<th " . $vwbar . "><nobr>$header</th>");
-  }
-  print("</tr>");
+    print("<tr class='box-table-title'><td>");
+    print("<strong>Current Function</strong>");
+    print("</td></tr>");
 
-  print("<tr class='box-table-title'><td>");
-  print("<strong>Current Function</strong>");
-  print("</td></tr>");
-
-  print("<tr>");
+    print("<tr>");
   // make this a self-reference to facilitate copy-pasting snippets to e-mails
-  print("<td><a href=''>$rep_symbol</a></td>");
+    print("<td><a href=''>$rep_symbol</a></td>");
 
-  if ($display_calls) {
-    // Call Count
-    print_td_num($symbol_info["ct"], $format_cbk["ct"]);
-    print_td_pct($symbol_info["ct"], $totals["ct"]);
-  }
+    if ($display_calls) {
+        // Call Count
+        print_td_num($symbol_info["ct"], $format_cbk["ct"]);
+        print_td_pct($symbol_info["ct"], $totals["ct"]);
+    }
 
   // Inclusive Metrics for current function
-  foreach ($metrics as $metric) {
-    print_td_num($symbol_info[$metric], $format_cbk[$metric], ($sort_col == $metric));
-    print_td_pct($symbol_info[$metric], $totals[$metric], ($sort_col == $metric));
-  }
-  print("</tr>");
+    foreach ($metrics as $metric) {
+        print_td_num($symbol_info[$metric], $format_cbk[$metric], ($sort_col == $metric));
+        print_td_pct($symbol_info[$metric], $totals[$metric], ($sort_col == $metric));
+    }
+    print("</tr>");
 
-  print("<tr class='box-table-title'>");
-  print("<td><strong>"
+    print("<tr class='box-table-title'>");
+    print("<td><strong>"
         ."Exclusive Metrics $diff_text for Current Function</strong></td>");
 
-  if ($display_calls) {
-    // Call Count
-    print("<td $vbar></td>");
-    print("<td $vbar></td>");
-  }
+    if ($display_calls) {
+        // Call Count
+        print("<td $vbar></td>");
+        print("<td $vbar></td>");
+    }
 
   // Exclusive Metrics for current function
-  foreach ($metrics as $metric) {
-    print_td_num($symbol_info["excl_" . $metric], $format_cbk["excl_" . $metric],
-                 ($sort_col == $metric),
-                 get_tooltip_attributes("Child", $metric));
-    print_td_pct($symbol_info["excl_" . $metric], $symbol_info[$metric],
-                 ($sort_col == $metric),
-                 get_tooltip_attributes("Child", $metric));
-  }
-  print("</tr>");
+    foreach ($metrics as $metric) {
+        print_td_num(
+            $symbol_info["excl_" . $metric],
+            $format_cbk["excl_" . $metric],
+            ($sort_col == $metric),
+            get_tooltip_attributes("Child", $metric)
+        );
+        print_td_pct(
+            $symbol_info["excl_" . $metric],
+            $symbol_info[$metric],
+            ($sort_col == $metric),
+            get_tooltip_attributes("Child", $metric)
+        );
+    }
+    print("</tr>");
 
   // list of callers/parent functions
-  $results = array();
-  if ($display_calls) {
-    $base_ct = $symbol_info["ct"];
-  } else {
-    $base_ct = 0;
-  }
-  foreach ($metrics as $metric) {
-    $base_info[$metric] = $symbol_info[$metric];
-  }
-  foreach ($run_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
-    if (($child == $rep_symbol) && ($parent)) {
-      $info_tmp = $info;
-      $info_tmp["fn"] = $parent;
-      $results[] = $info_tmp;
+    $results = array();
+    if ($display_calls) {
+        $base_ct = $symbol_info["ct"];
+    } else {
+        $base_ct = 0;
     }
-  }
-  usort($results, 'sort_cbk');
+    foreach ($metrics as $metric) {
+        $base_info[$metric] = $symbol_info[$metric];
+    }
+    foreach ($run_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
+        if (($child == $rep_symbol) && ($parent)) {
+            $info_tmp = $info;
+            $info_tmp["fn"] = $parent;
+            $results[] = $info_tmp;
+        }
+    }
+    usort($results, 'sort_cbk');
 
-  if (count($results) > 0) {
-    print_pc_array($url_params, $results, $base_ct, $base_info, true,
-                   $run1, $run2);
-  }
+    if (count($results) > 0) {
+        print_pc_array(
+            $url_params,
+            $results,
+            $base_ct,
+            $base_info,
+            true,
+            $run1,
+            $run2
+        );
+    }
 
   // list of callees/child functions
-  $results = array();
-  $base_ct = 0;
-  foreach ($run_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
-    if ($parent == $rep_symbol) {
-      $info_tmp = $info;
-      $info_tmp["fn"] = $child;
-      $results[] = $info_tmp;
-      if ($display_calls) {
-        $base_ct += $info["ct"];
-      }
+    $results = array();
+    $base_ct = 0;
+    foreach ($run_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
+        if ($parent == $rep_symbol) {
+            $info_tmp = $info;
+            $info_tmp["fn"] = $child;
+            $results[] = $info_tmp;
+            if ($display_calls) {
+                $base_ct += $info["ct"];
+            }
+        }
     }
-  }
-  usort($results, 'sort_cbk');
+    usort($results, 'sort_cbk');
 
-  if (count($results)) {
-    print_pc_array($url_params, $results, $base_ct, $base_info, false,
-                   $run1, $run2);
-  }
+    if (count($results)) {
+        print_pc_array(
+            $url_params,
+            $results,
+            $base_ct,
+            $base_info,
+            false,
+            $run1,
+            $run2
+        );
+    }
 
-  print("</table>");
+    print("</table>");
 
   // These will be used for pop-up tips/help.
   // Related javascript code is in: xhprof_report.js
-  print("\n");
-  print('<script language="javascript">' . "\n");
-  print("var func_name = '\"" . $rep_symbol . "\"';\n");
-  print("var total_child_ct  = " . $base_ct . ";\n");
-  if ($display_calls) {
-    print("var func_ct   = " . $symbol_info["ct"] . ";\n" );
-  }
-  print("var func_metrics = new Array();\n");
-  print("var metrics_col  = new Array();\n");
-  print("var metrics_desc  = new Array();\n");
-  if ($diff_mode) {
-    print("var diff_mode = true;\n");
-  } else {
-    print("var diff_mode = false;\n");
-  }
-  $column_index = 3; // First three columns are Func Name, Calls, Calls%
-  foreach ($metrics as $metric) {
-    print("func_metrics[\"" . $metric . "\"] = " . round($symbol_info[$metric]) . ";\n" );
-    print("metrics_col[\"". $metric . "\"] = " . $column_index . ";\n");
-    print("metrics_desc[\"". $metric . "\"] = \"" . $possible_metrics[$metric][2] . "\";\n");
+    print("\n");
+    print('<script language="javascript">' . "\n");
+    print("var func_name = '\"" . $rep_symbol . "\"';\n");
+    print("var total_child_ct  = " . $base_ct . ";\n");
+    if ($display_calls) {
+        print("var func_ct   = " . $symbol_info["ct"] . ";\n" );
+    }
+    print("var func_metrics = new Array();\n");
+    print("var metrics_col  = new Array();\n");
+    print("var metrics_desc  = new Array();\n");
+    if ($diff_mode) {
+        print("var diff_mode = true;\n");
+    } else {
+        print("var diff_mode = false;\n");
+    }
+    $column_index = 3; // First three columns are Func Name, Calls, Calls%
+    foreach ($metrics as $metric) {
+        print("func_metrics[\"" . $metric . "\"] = " . round($symbol_info[$metric]) . ";\n" );
+        print("metrics_col[\"". $metric . "\"] = " . $column_index . ";\n");
+        print("metrics_desc[\"". $metric . "\"] = \"" . $possible_metrics[$metric][2] . "\";\n");
 
-    // each metric has two columns..
-    $column_index += 2;
-  }
-  print('</script>');
-  print("\n");
-
+        // each metric has two columns..
+        $column_index += 2;
+    }
+    print('</script>');
+    print("\n");
 }
 
 /**
@@ -1276,18 +1393,27 @@ function symbol_report($url_params,
  *
  * @author Kannan
  */
-function profiler_single_run_report ($url_params,
-                                     $xhprof_data,
-                                     $run_desc,
-                                     $rep_symbol,
-                                     $sort,
-                                     $run,
-                                     $run_details = null) {
+function profiler_single_run_report(
+    $url_params,
+    $xhprof_data,
+    $run_desc,
+    $rep_symbol,
+    $sort,
+    $run,
+    $run_details = null
+) {
 
-  init_metrics($xhprof_data, $rep_symbol, $sort, false);
+    init_metrics($xhprof_data, $rep_symbol, $sort, false);
 
-  profiler_report($url_params, $rep_symbol, $sort, $run, $run_desc,
-                  $xhprof_data, $run_details);
+    profiler_report(
+        $url_params,
+        $rep_symbol,
+        $sort,
+        $run,
+        $run_desc,
+        $xhprof_data,
+        $run_details
+    );
 }
 
 
@@ -1297,29 +1423,33 @@ function profiler_single_run_report ($url_params,
  *
  * @author Kannan
  */
-function profiler_diff_report($url_params,
-                              $xhprof_data1,
-                              $run1_desc,
-                              $xhprof_data2,
-                              $run2_desc,
-                              $rep_symbol,
-                              $sort,
-                              $run1,
-                              $run2) {
+function profiler_diff_report(
+    $url_params,
+    $xhprof_data1,
+    $run1_desc,
+    $xhprof_data2,
+    $run2_desc,
+    $rep_symbol,
+    $sort,
+    $run1,
+    $run2
+) {
 
 
   // Initialize what metrics we'll display based on data in Run2
-  init_metrics($xhprof_data2, $rep_symbol, $sort, true);
+    init_metrics($xhprof_data2, $rep_symbol, $sort, true);
 
-  profiler_report($url_params,
-                  $rep_symbol,
-                  $sort,
-                  $run1,
-                  $run1_desc,
-                  $xhprof_data1,
-                  $run2,
-                  $run2_desc,
-                  $xhprof_data2);
+    profiler_report(
+        $url_params,
+        $rep_symbol,
+        $sort,
+        $run1,
+        $run1_desc,
+        $xhprof_data1,
+        $run2,
+        $run2_desc,
+        $xhprof_data2
+    );
 }
 
 
@@ -1357,66 +1487,83 @@ function profiler_diff_report($url_params,
  * @param string  $run2         New run id (for diff reports)
  *
  */
-function displayXHProfReport($xhprof_runs_impl, $url_params, $source,
-                             $run, $wts, $symbol, $sort, $run1, $run2) {
+function displayXHProfReport(
+    $xhprof_runs_impl,
+    $url_params,
+    $source,
+    $run,
+    $wts,
+    $symbol,
+    $sort,
+    $run1,
+    $run2
+) {
 
-  if ($run) {                              // specific run to display?
+    if ($run) {                              // specific run to display?
 
-    // run may be a single run or a comma separate list of runs
-    // that'll be aggregated. If "wts" (a comma separated list
-    // of integral weights is specified), the runs will be
-    // aggregated in that ratio.
-    //
-    $runs_array = explode(",", $run);
+        // run may be a single run or a comma separate list of runs
+        // that'll be aggregated. If "wts" (a comma separated list
+        // of integral weights is specified), the runs will be
+        // aggregated in that ratio.
+        //
+        $runs_array = explode(",", $run);
 
-    if (count($runs_array) == 1)
-    {
-        global $run_details;
-        list($xhprof_data, $run_details) = $xhprof_runs_impl->get_run($runs_array[0],
-                                                $source,
-                                                $description);
+        if (count($runs_array) == 1) {
+            global $run_details;
+            list($xhprof_data, $run_details) = $xhprof_runs_impl->get_run(
+                $runs_array[0],
+                $source,
+                $description
+            );
+        } else {
+            if (!empty($wts)) {
+                $wts_array  = explode(",", $wts);
+            } else {
+                $wts_array = null;
+            }
+            $data = xhprof_aggregate_runs(
+                $xhprof_runs_impl,
+                $runs_array,
+                $wts_array,
+                $source,
+                false
+            );
+            $xhprof_data = $data['raw'];
+            $description = $data['description'];
+        }
+
+        if (!$xhprof_data) {
+            echo "Given XHProf Run not found.";
+            return;
+        }
+
+
+        profiler_single_run_report(
+            $url_params,
+            $xhprof_data,
+            $description,
+            $symbol,
+            $sort,
+            $run,
+            $run_details
+        );
+    } elseif ($run1 && $run2) {                  // diff report for two runs
+
+        list($xhprof_data1, $run_details1) = $xhprof_runs_impl->get_run($run1, $source, $description1);
+        list($xhprof_data2, $run_details2) = $xhprof_runs_impl->get_run($run2, $source, $description2);
+
+        profiler_diff_report(
+            $url_params,
+            $xhprof_data1,
+            $description1,
+            $xhprof_data2,
+            $description2,
+            $symbol,
+            $sort,
+            $run1,
+            $run2
+        );
     } else {
-      if (!empty($wts)) {
-        $wts_array  = explode(",", $wts);
-      } else {
-        $wts_array = null;
-      }
-      $data = xhprof_aggregate_runs($xhprof_runs_impl,
-                                    $runs_array, $wts_array, $source, false);
-      $xhprof_data = $data['raw'];
-      $description = $data['description'];
+        echo "No XHProf runs specified in the URL.";
     }
-
-    if (!$xhprof_data) {
-        echo "Given XHProf Run not found.";
-        return;
-    }
-
-
-    profiler_single_run_report($url_params,
-                               $xhprof_data,
-                               $description,
-                               $symbol,
-                               $sort,
-                               $run,
-                               $run_details);
-
-  } else if ($run1 && $run2) {                  // diff report for two runs
-
-    list($xhprof_data1, $run_details1) = $xhprof_runs_impl->get_run($run1, $source, $description1);
-    list($xhprof_data2, $run_details2) = $xhprof_runs_impl->get_run($run2, $source, $description2);
-
-    profiler_diff_report($url_params,
-                         $xhprof_data1,
-                         $description1,
-                         $xhprof_data2,
-                         $description2,
-                         $symbol,
-                         $sort,
-                         $run1,
-                         $run2);
-
-  } else {
-    echo "No XHProf runs specified in the URL.";
-  }
 }

--- a/xhprof_lib/utils/Db/Abstract.php
+++ b/xhprof_lib/utils/Db/Abstract.php
@@ -28,6 +28,4 @@ abstract class Db_Abstract
     {
         throw new RuntimeException("Method '".get_called_class()."::".__FUNCTION__."' not implemented");
     }
-    
-    
 }

--- a/xhprof_lib/utils/Db/Mssql.php
+++ b/xhprof_lib/utils/Db/Mssql.php
@@ -50,8 +50,7 @@ class Db_Mssql extends Db_Abstract
     public function connect()
     {
         $linkid = mssql_connect($this->config['dbhost'], $this->config['dbuser'], $this->config['dbpass']);
-        if ($linkid === FALSE)
-        {
+        if ($linkid === false) {
             xhprof_error("Could not connect to db");
             throw new Exception("Unable to connect to database");
             return false;

--- a/xhprof_lib/utils/Db/Mysql.php
+++ b/xhprof_lib/utils/Db/Mysql.php
@@ -38,8 +38,7 @@ class Db_Mysql extends Db_Abstract
     public function connect()
     {
         $this->linkID = mysql_connect($this->config['dbhost'], $this->config['dbuser'], $this->config['dbpass']);
-        if ($this->linkID === FALSE)
-        {
+        if ($this->linkID === false) {
             xhprof_error("Could not connect to db");
             throw new Exception("Unable to connect to database");
             return false;

--- a/xhprof_lib/utils/Db/Mysqli.php
+++ b/xhprof_lib/utils/Db/Mysqli.php
@@ -38,8 +38,7 @@ class Db_Mysqli extends Db_Abstract
     public function connect()
     {
         $this->linkID = mysqli_connect($this->config['dbhost'], $this->config['dbuser'], $this->config['dbpass'], $this->config['dbname']);
-        if ($this->linkID === FALSE)
-        {
+        if ($this->linkID === false) {
             xhprof_error("Could not connect to db");
             throw new Exception("Unable to connect to database");
             return false;

--- a/xhprof_lib/utils/Db/Pdo.php
+++ b/xhprof_lib/utils/Db/Pdo.php
@@ -40,8 +40,7 @@ class Db_Pdo extends Db_Abstract
     {
         $connectionString = $this->config['dbtype'] . ':host=' . $this->config['dbhost'] . ';dbname=' . $this->config['dbname'];
         $db = new PDO($connectionString, $this->config['dbuser'], $this->config['dbpass']);
-        if ($db === FALSE)
-        {
+        if ($db === false) {
             xhprof_error("Could not connect to db");
             $run_desc = "could not connect to db";
             throw new Exception("Unable to connect to database");

--- a/xhprof_lib/utils/Db/Sqlsrv.php
+++ b/xhprof_lib/utils/Db/Sqlsrv.php
@@ -2,24 +2,24 @@
 
   /**
   * When setting the `id` column, consider the length of the prefix you're specifying in $this->prefix
-  * 
+  *
   *
 CREATE TABLE dbo.details
 (
-   id nchar(17) NOT NULL, 
-   url nvarchar(255) NULL DEFAULT NULL, 
-   c_url nvarchar(255) NULL DEFAULT NULL, 
-   timestamp datetime NOT NULL DEFAULT getdate(), 
-   [server name] nvarchar(64) NULL DEFAULT NULL, 
-   perfdata nvarchar(max) NULL, 
-   type smallint NULL DEFAULT NULL, 
-   cookie nvarchar(max) NULL, 
-   post nvarchar(max) NULL, 
-   get nvarchar(max) NULL, 
-   pmu int NULL DEFAULT NULL, 
-   wt int NULL DEFAULT NULL, 
-   cpu int NULL DEFAULT NULL, 
-   server_id nchar(3) NOT NULL DEFAULT N't11', 
+   id nchar(17) NOT NULL,
+   url nvarchar(255) NULL DEFAULT NULL,
+   c_url nvarchar(255) NULL DEFAULT NULL,
+   timestamp datetime NOT NULL DEFAULT getdate(),
+   [server name] nvarchar(64) NULL DEFAULT NULL,
+   perfdata nvarchar(max) NULL,
+   type smallint NULL DEFAULT NULL,
+   cookie nvarchar(max) NULL,
+   post nvarchar(max) NULL,
+   get nvarchar(max) NULL,
+   pmu int NULL DEFAULT NULL,
+   wt int NULL DEFAULT NULL,
+   cpu int NULL DEFAULT NULL,
+   server_id nchar(3) NOT NULL DEFAULT N't11',
    aggregateCalls_include nvarchar(255) NULL DEFAULT NULL,
    CONSTRAINT PK_details_id PRIMARY KEY (id)
 )
@@ -41,7 +41,7 @@ CREATE NONCLUSTERED INDEX dbo.pmu
 GO
 CREATE NONCLUSTERED INDEX dbo.timestamp
    ON dbo.details (timestamp
-  
+
 */
 
 require_once XHPROF_LIB_ROOT.'/utils/Db/Abstract.php';
@@ -51,10 +51,9 @@ class Db_Sqlsrv extends Db_Abstract
     
     public function connect()
     {
-        $connectionInfo = array("UID" => $this->config['dbuser'], "PWD" =>  $this->config['dbpass'], "Database"=>$this->config['dbname'], "ReturnDatesAsStrings" => TRUE);
+        $connectionInfo = array("UID" => $this->config['dbuser'], "PWD" =>  $this->config['dbpass'], "Database"=>$this->config['dbname'], "ReturnDatesAsStrings" => true);
         $linkid = sqlsrv_connect($this->config['dbhost'], $connectionInfo);
-        if ($linkid === FALSE)
-        {
+        if ($linkid === false) {
             xhprof_error("Could not connect to db");
             throw new Exception("Unable to connect to database");
             return false;

--- a/xhprof_lib/utils/callgraph_utils.php
+++ b/xhprof_lib/utils/callgraph_utils.php
@@ -38,18 +38,19 @@ $xhprof_legal_image_types = array(
  * @param string  HTTP header value, like 'http://www.example.com/'
  *
  */
-function xhprof_http_header($name, $value) {
+function xhprof_http_header($name, $value)
+{
 
-  if (!$name) {
-    xhprof_error('http_header usage');
-    return null;
-  }
+    if (!$name) {
+        xhprof_error('http_header usage');
+        return null;
+    }
 
-  if (!is_string($value)) {
-    xhprof_error('http_header value not a string');
-  }
+    if (!is_string($value)) {
+        xhprof_error('http_header value not a string');
+    }
 
-  header($name.': '.$value, true);
+    header($name.': '.$value, true);
 }
 
 /**
@@ -57,27 +58,28 @@ function xhprof_http_header($name, $value) {
  *
  * @author cjiang
  */
-function xhprof_generate_mime_header($type, $length) {
-  switch ($type) {
-    case 'jpg':
-      $mime = 'image/jpeg';
-      break;
-    case 'gif':
-      $mime = 'image/gif';
-      break;
-    case 'png':
-      $mime = 'image/png';
-      break;
-    case 'ps':
-      $mime = 'application/postscript';
-    default:
-      $mime = false;
-  }
+function xhprof_generate_mime_header($type, $length)
+{
+    switch ($type) {
+        case 'jpg':
+            $mime = 'image/jpeg';
+            break;
+        case 'gif':
+            $mime = 'image/gif';
+            break;
+        case 'png':
+            $mime = 'image/png';
+            break;
+        case 'ps':
+            $mime = 'application/postscript';
+        default:
+            $mime = false;
+    }
 
-  if ($mime) {
-    xhprof_http_header('Content-type', $mime);
-    xhprof_http_header('Content-length', (string)$length);
-  }
+    if ($mime) {
+        xhprof_http_header('Content-type', $mime);
+        xhprof_http_header('Content-length', (string)$length);
+    }
 }
 
 /**
@@ -93,25 +95,28 @@ function xhprof_generate_mime_header($type, $length) {
  *
  * @author cjiang
  */
-function xhprof_generate_image_by_dot($dot_script, $type) {
+function xhprof_generate_image_by_dot($dot_script, $type)
+{
   // get config => yep really dirty - but unobstrusive
-  global $_xhprof;
+    global $_xhprof;
   
-  $errorFile    = $_xhprof['dot_errfile'];
-  $tmpDirectory = $_xhprof['dot_tempdir'];
-  $dotBinary    = $_xhprof['dot_binary'];
+    $errorFile    = $_xhprof['dot_errfile'];
+    $tmpDirectory = $_xhprof['dot_tempdir'];
+    $dotBinary    = $_xhprof['dot_binary'];
  
   // detect windows
-  if (stristr(PHP_OS, 'WIN') && !stristr(PHP_OS, 'Darwin')) {
-    return xhprof_generate_image_by_dot_on_win($dot_script, 
-                                               $type, 
-                                               $errorFile, 
-                                               $tmpDirectory, 
-                                               $dotBinary);
-  }
+    if (stristr(PHP_OS, 'WIN') && !stristr(PHP_OS, 'Darwin')) {
+        return xhprof_generate_image_by_dot_on_win(
+            $dot_script,
+            $type,
+            $errorFile,
+            $tmpDirectory,
+            $dotBinary
+        );
+    }
 
   // parts of the original source
-  $descriptorspec = array(
+    $descriptorspec = array(
        // stdin is a pipe that the child will read from
        0 => array("pipe", "r"),
        // stdout is a pipe that the child will write to
@@ -120,39 +125,38 @@ function xhprof_generate_image_by_dot($dot_script, $type) {
        2 => array("file", $errorFile, "a")
        );
 
-  $cmd = ' "'.$dotBinary.'" -T'.$type;
+    $cmd = ' "'.$dotBinary.'" -T'.$type;
 
-  $process = proc_open($cmd, $descriptorspec, $pipes, $tmpDirectory, array());
+    $process = proc_open($cmd, $descriptorspec, $pipes, $tmpDirectory, array());
 
-  if (is_resource($process)) {
-    fwrite($pipes[0], $dot_script);
-    fclose($pipes[0]);
+    if (is_resource($process)) {
+        fwrite($pipes[0], $dot_script);
+        fclose($pipes[0]);
 
-   $output = stream_get_contents($pipes[1]);
-    fclose($pipes[1]);
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
 
-    proc_close($process);
-    if ($output == "" && filesize($errorFile) > 0)
-    {
-      die("Error producing callgraph, check $errorFile");
+        proc_close($process);
+        if ($output == "" && filesize($errorFile) > 0) {
+            die("Error producing callgraph, check $errorFile");
+        }
+        return $output;
     }
-    return $output;
-  }
-  print "failed to shell execute cmd=\"$cmd\"\n";
+    print "failed to shell execute cmd=\"$cmd\"\n";
 
-  $error = error_get_last();
-  if (isset($error['message'])) {
-    print($error['message'] . "\n");
-  }
+    $error = error_get_last();
+    if (isset($error['message'])) {
+        print($error['message'] . "\n");
+    }
 
-  exit();
+    exit();
 }
 
 /**
- * Generate image according to DOT script. This function will make the 
+ * Generate image according to DOT script. This function will make the
  * process working on windows boxes (some win-boxes seems to having problems
- * with creating processes via proc_open so we do it the lame win way by 
- * creating and writing to temp-files and reading them in again ... 
+ * with creating processes via proc_open so we do it the lame win way by
+ * creating and writing to temp-files and reading them in again ...
  * not really nice but functional
  *
  * @param dot_script, string, the script for DOT to generate the image.
@@ -164,70 +168,72 @@ function xhprof_generate_image_by_dot($dot_script, $type) {
  *
  * @author Benjamin Carl <opensource@clickalicious.de>
  */
-function xhprof_generate_image_by_dot_on_win($dot_script, 
-                                             $type, 
-                                             $errorFile, 
-                                             $tmpDirectory, 
-                                             $dotBin
+function xhprof_generate_image_by_dot_on_win(
+    $dot_script,
+    $type,
+    $errorFile,
+    $tmpDirectory,
+    $dotBin
 ) {
   // assume no error
-  $error = false;
+    $error = false;
 
   // get unique identifier
-  $uid = md5(time());
+    $uid = md5(time());
 
   // files we handle with
-  $files = array(
+    $files = array(
     'dot'   => $tmpDirectory.'\\'.$uid.'.dot',
     'img' => $tmpDirectory.'\\'.$uid.'.'.$type
-  );
+    );
 
   // build command for dot.exe
-  $cmd = '"'.$dotBin.'" -T'.$type.' "'.$files['dot'].'" -o "'.$files['img'].'"';
+    $cmd = '"'.$dotBin.'" -T'.$type.' "'.$files['dot'].'" -o "'.$files['img'].'"';
 
   // 1. write dot script temp
-  file_put_contents($files['dot'], $dot_script);
+    file_put_contents($files['dot'], $dot_script);
 
   // 2. call dot-binary with temp dot script and write file (out) type
-  shell_exec($cmd);
+    shell_exec($cmd);
   
   // 3. read in the img
-  $output = file_get_contents($files['img']);
-  if ($output == '' 
-      || !file_exists($files['img']) 
+    $output = file_get_contents($files['img']);
+    if ($output == ''
+      || !file_exists($files['img'])
       || filesize($files['img']) == 0
-  ) {
-    $error = true;
-  }
+    ) {
+        $error = true;
+    }
 
   // 4. delete temp files
-  foreach ($files as $type => $file) {
-    unlink($file);
-  }
+    foreach ($files as $type => $file) {
+        unlink($file);
+    }
 
   // 5. check for possible error (empty result)
-  if ($error) {
-    die("Error producing callgraph!");
-  }
+    if ($error) {
+        die("Error producing callgraph!");
+    }
 
   // 6. return result
-  return $output;
+    return $output;
 }
 
 /*
  * Get the children list of all nodes.
  */
-function xhprof_get_children_table($raw_data) {
-  $children_table = array();
-  foreach ($raw_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
-    if (!isset($children_table[$parent])) {
-      $children_table[$parent] = array($child);
-    } else {
-      $children_table[$parent][] = $child;
+function xhprof_get_children_table($raw_data)
+{
+    $children_table = array();
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
+        if (!isset($children_table[$parent])) {
+            $children_table[$parent] = array($child);
+        } else {
+            $children_table[$parent][] = $child;
+        }
     }
-  }
-  return $children_table;
+    return $children_table;
 }
 
 /**
@@ -247,254 +253,279 @@ function xhprof_get_children_table($raw_data) {
  *
  * @author cjiang
  */
-function xhprof_generate_dot_script($raw_data, $threshold, $source, $page,
-                                    $func, $critical_path, $right=null,
-                                    $left=null) {
+function xhprof_generate_dot_script(
+    $raw_data,
+    $threshold,
+    $source,
+    $page,
+    $func,
+    $critical_path,
+    $right = null,
+    $left = null
+) {
 
-  $max_width = 5;
-  $max_height = 3.5;
-  $max_fontsize = 35;
-  $max_sizing_ratio = 20;
+    $max_width = 5;
+    $max_height = 3.5;
+    $max_fontsize = 35;
+    $max_sizing_ratio = 20;
 
-  $totals;
+    $totals;
 
-  if ($left === null) {
-    // init_metrics($raw_data, null, null);
-  }
-  $sym_table = xhprof_compute_flat_info($raw_data, $totals);
-
-  if ($critical_path) {
-    $children_table = xhprof_get_children_table($raw_data);
-    $node = "main()";
-    $path = array();
-    $path_edges = array();
-    $visited = array();
-    while ($node) {
-      $visited[$node] = true;
-      if (isset($children_table[$node])) {
-        $max_child = null;
-        foreach ($children_table[$node] as $child) {
-
-          if (isset($visited[$child])) {
-            continue;
-          }
-          if ($max_child === null ||
-            abs($raw_data[xhprof_build_parent_child_key($node,
-                                                        $child)]["wt"]) >
-            abs($raw_data[xhprof_build_parent_child_key($node,
-                                                        $max_child)]["wt"])) {
-            $max_child = $child;
-          }
-        }
-        if ($max_child !== null) {
-          $path[$max_child] = true;
-          $path_edges[xhprof_build_parent_child_key($node, $max_child)] = true;
-        }
-        $node = $max_child;
-      } else {
-        $node = null;
-      }
+    if ($left === null) {
+        // init_metrics($raw_data, null, null);
     }
-  }
+    $sym_table = xhprof_compute_flat_info($raw_data, $totals);
+
+    if ($critical_path) {
+        $children_table = xhprof_get_children_table($raw_data);
+        $node = "main()";
+        $path = array();
+        $path_edges = array();
+        $visited = array();
+        while ($node) {
+            $visited[$node] = true;
+            if (isset($children_table[$node])) {
+                $max_child = null;
+                foreach ($children_table[$node] as $child) {
+                    if (isset($visited[$child])) {
+                        continue;
+                    }
+                    if ($max_child === null ||
+                    abs($raw_data[xhprof_build_parent_child_key(
+                        $node,
+                        $child
+                    )]["wt"]) >
+                    abs($raw_data[xhprof_build_parent_child_key(
+                        $node,
+                        $max_child
+                    )]["wt"])) {
+                        $max_child = $child;
+                    }
+                }
+                if ($max_child !== null) {
+                    $path[$max_child] = true;
+                    $path_edges[xhprof_build_parent_child_key($node, $max_child)] = true;
+                }
+                $node = $max_child;
+            } else {
+                $node = null;
+            }
+        }
+    }
 
   // if it is a benchmark callgraph, we make the benchmarked function the root.
- if ($source == "bm" && array_key_exists("main()", $sym_table)) {
-    $total_times = $sym_table["main()"]["ct"];
-    $remove_funcs = array("main()",
+    if ($source == "bm" && array_key_exists("main()", $sym_table)) {
+          $total_times = $sym_table["main()"]["ct"];
+          $remove_funcs = array("main()",
                           "hotprofiler_disable",
                           "call_user_func_array",
                           "xhprof_disable");
 
-    foreach ($remove_funcs as $cur_del_func) {
-      if (array_key_exists($cur_del_func, $sym_table) &&
-          $sym_table[$cur_del_func]["ct"] == $total_times) {
-        unset($sym_table[$cur_del_func]);
-      }
+        foreach ($remove_funcs as $cur_del_func) {
+            if (array_key_exists($cur_del_func, $sym_table) &&
+               $sym_table[$cur_del_func]["ct"] == $total_times) {
+                unset($sym_table[$cur_del_func]);
+            }
+        }
     }
-  }
 
   // use the function to filter out irrelevant functions.
-  if (!empty($func)) {
-    $interested_funcs = array();
-    foreach ($raw_data as $parent_child => $info) {
-      list($parent, $child) = xhprof_parse_parent_child($parent_child);
-      if ($parent == $func || $child == $func) {
-        $interested_funcs[$parent] = 1;
-        $interested_funcs[$child] = 1;
-      }
+    if (!empty($func)) {
+        $interested_funcs = array();
+        foreach ($raw_data as $parent_child => $info) {
+            list($parent, $child) = xhprof_parse_parent_child($parent_child);
+            if ($parent == $func || $child == $func) {
+                $interested_funcs[$parent] = 1;
+                $interested_funcs[$child] = 1;
+            }
+        }
+        foreach ($sym_table as $symbol => $info) {
+            if (!array_key_exists($symbol, $interested_funcs)) {
+                unset($sym_table[$symbol]);
+            }
+        }
     }
-    foreach ($sym_table as $symbol => $info) {
-      if (!array_key_exists($symbol, $interested_funcs)) {
-        unset($sym_table[$symbol]);
-      }
-    }
-  }
 
-  $result = "digraph call_graph {\n";
+    $result = "digraph call_graph {\n";
 
   // Filter out functions whose exclusive time ratio is below threshold, and
   // also assign a unique integer id for each function to be generated. In the
   // meantime, find the function with the most exclusive time (potentially the
   // performance bottleneck).
-  $cur_id = 0; $max_wt = 0;
-  foreach ($sym_table as $symbol => $info) {
-    if (empty($func) && abs($info["wt"] / $totals["wt"]) < $threshold) {
-      unset($sym_table[$symbol]);
-      continue;
+    $cur_id = 0;
+    $max_wt = 0;
+    foreach ($sym_table as $symbol => $info) {
+        if (empty($func) && abs($info["wt"] / $totals["wt"]) < $threshold) {
+            unset($sym_table[$symbol]);
+            continue;
+        }
+        if ($max_wt == 0 || $max_wt < abs($info["excl_wt"])) {
+            $max_wt = abs($info["excl_wt"]);
+        }
+        $sym_table[$symbol]["id"] = $cur_id;
+        $cur_id ++;
     }
-    if ($max_wt == 0 || $max_wt < abs($info["excl_wt"])) {
-      $max_wt = abs($info["excl_wt"]);
-    }
-    $sym_table[$symbol]["id"] = $cur_id;
-    $cur_id ++;
-  }
 
   // Generate all nodes' information.
-  foreach ($sym_table as $symbol => $info) {
-    if ($info["excl_wt"] == 0) {
-      $sizing_factor = $max_sizing_ratio;
-    } else {
-      $sizing_factor = $max_wt / abs($info["excl_wt"]) ;
-      if ($sizing_factor > $max_sizing_ratio) {
-        $sizing_factor = $max_sizing_ratio;
-      }
-    }
-    $fillcolor = (($sizing_factor < 1.5) ?
+    foreach ($sym_table as $symbol => $info) {
+        if ($info["excl_wt"] == 0) {
+            $sizing_factor = $max_sizing_ratio;
+        } else {
+            $sizing_factor = $max_wt / abs($info["excl_wt"]) ;
+            if ($sizing_factor > $max_sizing_ratio) {
+                $sizing_factor = $max_sizing_ratio;
+            }
+        }
+        $fillcolor = (($sizing_factor < 1.5) ?
                   ", style=filled, fillcolor=red" : "");
 
-    if ($critical_path) {
-      // highlight nodes along critical path.
-      if (!$fillcolor && array_key_exists($symbol, $path)) {
-        $fillcolor = ", style=filled, fillcolor=yellow";
-      }
-    }
+        if ($critical_path) {
+              // highlight nodes along critical path.
+            if (!$fillcolor && array_key_exists($symbol, $path)) {
+                $fillcolor = ", style=filled, fillcolor=yellow";
+            }
+        }
 
-    $fontsize =", fontsize="
+        $fontsize =", fontsize="
                .(int)($max_fontsize / (($sizing_factor - 1) / 10 + 1));
 
-    $width = ", width=".sprintf("%.1f", $max_width / $sizing_factor);
-    $height = ", height=".sprintf("%.1f", $max_height / $sizing_factor);
+        $width = ", width=".sprintf("%.1f", $max_width / $sizing_factor);
+        $height = ", height=".sprintf("%.1f", $max_height / $sizing_factor);
 
-    if ($symbol == "main()") {
-      $shape = "octagon";
-      $name ="Total: ".($totals["wt"]/1000.0)." ms\\n";
-      $name .= addslashes(isset($page) ? $page : $symbol);
-    } else {
-      $shape = "box";
-      $name = addslashes($symbol)."\\nInc: ". sprintf("%.3f",$info["wt"]/1000) .
-              " ms (" . sprintf("%.1f%%", 100 * $info["wt"]/$totals["wt"]).")";
-    }
-    if ($left === null) {
-      $label = ", label=\"".$name."\\nExcl: "
-               .(sprintf("%.3f",$info["excl_wt"]/1000.0))." ms ("
-               .sprintf("%.1f%%", 100 * $info["excl_wt"]/$totals["wt"])
-               . ")\\n".$info["ct"]." total calls\"";
-    } else {
-      if (isset($left[$symbol]) && isset($right[$symbol])) {
-         $label = ", label=\"".addslashes($symbol).
-                  "\\nInc: ".(sprintf("%.3f",$left[$symbol]["wt"]/1000.0))
-                  ." ms - "
-                  .(sprintf("%.3f",$right[$symbol]["wt"]/1000.0))." ms = "
-                  .(sprintf("%.3f",$info["wt"]/1000.0))." ms".
-                  "\\nExcl: "
-                  .(sprintf("%.3f",$left[$symbol]["excl_wt"]/1000.0))
-                  ." ms - ".(sprintf("%.3f",$right[$symbol]["excl_wt"]/1000.0))
-                   ." ms = ".(sprintf("%.3f",$info["excl_wt"]/1000.0))." ms".
-                  "\\nCalls: ".(sprintf("%.3f",$left[$symbol]["ct"]))." - "
-                   .(sprintf("%.3f",$right[$symbol]["ct"]))." = "
-                   .(sprintf("%.3f",$info["ct"]))."\"";
-      } else if (isset($left[$symbol])) {
-        $label = ", label=\"".addslashes($symbol).
-                  "\\nInc: ".(sprintf("%.3f",$left[$symbol]["wt"]/1000.0))
-                   ." ms - 0 ms = ".(sprintf("%.3f",$info["wt"]/1000.0))
-                   ." ms"."\\nExcl: "
-                   .(sprintf("%.3f",$left[$symbol]["excl_wt"]/1000.0))
-                   ." ms - 0 ms = "
-                   .(sprintf("%.3f",$info["excl_wt"]/1000.0))." ms".
-                  "\\nCalls: ".(sprintf("%.3f",$left[$symbol]["ct"]))." - 0 = "
-                  .(sprintf("%.3f",$info["ct"]))."\"";
-      } else {
-        $label = ", label=\"".addslashes($symbol).
-                  "\\nInc: 0 ms - "
-                  .(sprintf("%.3f",$right[$symbol]["wt"]/1000.0))
-                  ." ms = ".(sprintf("%.3f",$info["wt"]/1000.0))." ms".
-                  "\\nExcl: 0 ms - "
-                  .(sprintf("%.3f",$right[$symbol]["excl_wt"]/1000.0))
-                  ." ms = ".(sprintf("%.3f",$info["excl_wt"]/1000.0))." ms".
-                  "\\nCalls: 0 - ".(sprintf("%.3f",$right[$symbol]["ct"]))
-                  ." = ".(sprintf("%.3f",$info["ct"]))."\"";
-      }
-    }
-    $result .= "N" . $sym_table[$symbol]["id"];
-    $result .= "[shape=$shape ".$label.$width
+        if ($symbol == "main()") {
+              $shape = "octagon";
+              $name ="Total: ".($totals["wt"]/1000.0)." ms\\n";
+              $name .= addslashes(isset($page) ? $page : $symbol);
+        } else {
+              $shape = "box";
+              $name = addslashes($symbol)."\\nInc: ". sprintf("%.3f", $info["wt"]/1000) .
+                      " ms (" . sprintf("%.1f%%", 100 * $info["wt"]/$totals["wt"]).")";
+        }
+        if ($left === null) {
+              $label = ", label=\"".$name."\\nExcl: "
+                       .(sprintf("%.3f", $info["excl_wt"]/1000.0))." ms ("
+                       .sprintf("%.1f%%", 100 * $info["excl_wt"]/$totals["wt"])
+                       . ")\\n".$info["ct"]." total calls\"";
+        } else {
+            if (isset($left[$symbol]) && isset($right[$symbol])) {
+                 $label = ", label=\"".addslashes($symbol).
+                          "\\nInc: ".(sprintf("%.3f", $left[$symbol]["wt"]/1000.0))
+                          ." ms - "
+                          .(sprintf("%.3f", $right[$symbol]["wt"]/1000.0))." ms = "
+                          .(sprintf("%.3f", $info["wt"]/1000.0))." ms".
+                          "\\nExcl: "
+                          .(sprintf("%.3f", $left[$symbol]["excl_wt"]/1000.0))
+                          ." ms - ".(sprintf("%.3f", $right[$symbol]["excl_wt"]/1000.0))
+                           ." ms = ".(sprintf("%.3f", $info["excl_wt"]/1000.0))." ms".
+                          "\\nCalls: ".(sprintf("%.3f", $left[$symbol]["ct"]))." - "
+                           .(sprintf("%.3f", $right[$symbol]["ct"]))." = "
+                           .(sprintf("%.3f", $info["ct"]))."\"";
+            } elseif (isset($left[$symbol])) {
+                $label = ", label=\"".addslashes($symbol).
+                        "\\nInc: ".(sprintf("%.3f", $left[$symbol]["wt"]/1000.0))
+                         ." ms - 0 ms = ".(sprintf("%.3f", $info["wt"]/1000.0))
+                         ." ms"."\\nExcl: "
+                         .(sprintf("%.3f", $left[$symbol]["excl_wt"]/1000.0))
+                         ." ms - 0 ms = "
+                         .(sprintf("%.3f", $info["excl_wt"]/1000.0))." ms".
+                        "\\nCalls: ".(sprintf("%.3f", $left[$symbol]["ct"]))." - 0 = "
+                        .(sprintf("%.3f", $info["ct"]))."\"";
+            } else {
+                $label = ", label=\"".addslashes($symbol).
+                        "\\nInc: 0 ms - "
+                        .(sprintf("%.3f", $right[$symbol]["wt"]/1000.0))
+                        ." ms = ".(sprintf("%.3f", $info["wt"]/1000.0))." ms".
+                        "\\nExcl: 0 ms - "
+                        .(sprintf("%.3f", $right[$symbol]["excl_wt"]/1000.0))
+                        ." ms = ".(sprintf("%.3f", $info["excl_wt"]/1000.0))." ms".
+                        "\\nCalls: 0 - ".(sprintf("%.3f", $right[$symbol]["ct"]))
+                        ." = ".(sprintf("%.3f", $info["ct"]))."\"";
+            }
+        }
+        $result .= "N" . $sym_table[$symbol]["id"];
+        $result .= "[shape=$shape ".$label.$width
                .$height.$fontsize.$fillcolor."];\n";
-  }
+    }
 
   // Generate all the edges' information.
-  foreach ($raw_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
 
-    if (isset($sym_table[$parent]) && isset($sym_table[$child]) &&
+        if (isset($sym_table[$parent]) && isset($sym_table[$child]) &&
         (empty($func) ||
          (!empty($func) && ($parent == $func || $child == $func)) )) {
+            $label = $info["ct"] == 1 ? $info["ct"]." call" : $info["ct"]." calls";
 
-      $label = $info["ct"] == 1 ? $info["ct"]." call" : $info["ct"]." calls";
-
-      $headlabel = $sym_table[$child]["wt"] > 0 ?
+            $headlabel = $sym_table[$child]["wt"] > 0 ?
                   sprintf("%.1f%%", 100 * $info["wt"]
                                     / $sym_table[$child]["wt"])
                   : "0.0%";
 
-      $taillabel = ($sym_table[$parent]["wt"] > 0) ?
-        sprintf("%.1f%%",
-                100 * $info["wt"] /
-                ($sym_table[$parent]["wt"] - $sym_table["$parent"]["excl_wt"]))
-        : "0.0%";
+            $taillabel = ($sym_table[$parent]["wt"] > 0) ?
+              sprintf(
+                  "%.1f%%",
+                  100 * $info["wt"] /
+                  ($sym_table[$parent]["wt"] - $sym_table["$parent"]["excl_wt"])
+              )
+              : "0.0%";
 
-      $linewidth= 1;
-      $arrow_size = 1;
+            $linewidth= 1;
+            $arrow_size = 1;
 
-      if ($critical_path &&
-          isset($path_edges[xhprof_build_parent_child_key($parent, $child)])) {
-        $linewidth = 10; $arrow_size=2;
-      }
+            if ($critical_path &&
+                isset($path_edges[xhprof_build_parent_child_key($parent, $child)])) {
+                    $linewidth = 10;
+                $arrow_size=2;
+            }
 
-      $result .= "N" . $sym_table[$parent]["id"] . " -> N"
-                 . $sym_table[$child]["id"];
-      $result .= "[arrowsize=$arrow_size, style=\"setlinewidth($linewidth)\","
-                 ." label=\""
-                 .$label."\", headlabel=\"".$headlabel
-                 ."\", taillabel=\"".$taillabel."\" ]";
-      $result .= ";\n";
-
+            $result .= "N" . $sym_table[$parent]["id"] . " -> N"
+                     . $sym_table[$child]["id"];
+            $result .= "[arrowsize=$arrow_size, style=\"setlinewidth($linewidth)\","
+                     ." label=\""
+                     .$label."\", headlabel=\"".$headlabel
+                     ."\", taillabel=\"".$taillabel."\" ]";
+            $result .= ";\n";
+        }
     }
-  }
-  $result = $result . "\n}";
+    $result = $result . "\n}";
 
-  return $result;
+    return $result;
 }
 
-function  xhprof_render_diff_image($xhprof_runs_impl, $run1, $run2,
-                                   $type, $threshold, $source) {
-  $total1;
-  $total2;
+function xhprof_render_diff_image(
+    $xhprof_runs_impl,
+    $run1,
+    $run2,
+    $type,
+    $threshold,
+    $source
+) {
+    $total1;
+    $total2;
 
-  list($raw_data1, $a) = $xhprof_runs_impl->get_run($run1, $source, $desc_unused);
-  list($raw_data2, $b) = $xhprof_runs_impl->get_run($run2, $source, $desc_unused);
+    list($raw_data1, $a) = $xhprof_runs_impl->get_run($run1, $source, $desc_unused);
+    list($raw_data2, $b) = $xhprof_runs_impl->get_run($run2, $source, $desc_unused);
 
   // init_metrics($raw_data1, null, null);
-  $children_table1 = xhprof_get_children_table($raw_data1);
-  $children_table2 = xhprof_get_children_table($raw_data2);
-  $symbol_tab1 = xhprof_compute_flat_info($raw_data1, $total1);
-  $symbol_tab2 = xhprof_compute_flat_info($raw_data2, $total2);
-  $run_delta = xhprof_compute_diff($raw_data1, $raw_data2);
-  $script = xhprof_generate_dot_script($run_delta, $threshold, $source,
-                                       null, null, true,
-                                       $symbol_tab1, $symbol_tab2);
-  $content = xhprof_generate_image_by_dot($script, $type);
+    $children_table1 = xhprof_get_children_table($raw_data1);
+    $children_table2 = xhprof_get_children_table($raw_data2);
+    $symbol_tab1 = xhprof_compute_flat_info($raw_data1, $total1);
+    $symbol_tab2 = xhprof_compute_flat_info($raw_data2, $total2);
+    $run_delta = xhprof_compute_diff($raw_data1, $raw_data2);
+    $script = xhprof_generate_dot_script(
+        $run_delta,
+        $threshold,
+        $source,
+        null,
+        null,
+        true,
+        $symbol_tab1,
+        $symbol_tab2
+    );
+    $content = xhprof_generate_image_by_dot($script, $type);
 
-  xhprof_generate_mime_header($type, strlen($content));
-  echo $content;
+    xhprof_generate_mime_header($type, strlen($content));
+    echo $content;
 }
 
 /**
@@ -515,23 +546,36 @@ function  xhprof_render_diff_image($xhprof_runs_impl, $run1, $run2,
  *
  * @author cjiang
  */
-function xhprof_get_content_by_run($xhprof_runs_impl, $run_id, $type,
-                                   $threshold, $func, $source,
-                                   $critical_path) {
-  if (!$run_id)
-    return "";
+function xhprof_get_content_by_run(
+    $xhprof_runs_impl,
+    $run_id,
+    $type,
+    $threshold,
+    $func,
+    $source,
+    $critical_path
+) {
+    if (!$run_id) {
+        return "";
+    }
 
-  list($raw_data, $a) = $xhprof_runs_impl->get_run($run_id, $source, $description);
-  if (!$raw_data) {
-    xhprof_error("Raw data is empty");
-    return "";
-  }
+    list($raw_data, $a) = $xhprof_runs_impl->get_run($run_id, $source, $description);
+    if (!$raw_data) {
+        xhprof_error("Raw data is empty");
+        return "";
+    }
 
-  $script = xhprof_generate_dot_script($raw_data, $threshold, $source,
-                                       $description, $func, $critical_path);
+    $script = xhprof_generate_dot_script(
+        $raw_data,
+        $threshold,
+        $source,
+        $description,
+        $func,
+        $critical_path
+    );
                     
-  $content = xhprof_generate_image_by_dot($script, $type);
-  return $content;
+    $content = xhprof_generate_image_by_dot($script, $type);
+    return $content;
 }
 
 /**
@@ -551,19 +595,32 @@ function xhprof_get_content_by_run($xhprof_runs_impl, $run_id, $type,
  * @param bool, does this run correspond to a PHProfLive run or a dev run?
  * @author cjiang
  */
-function xhprof_render_image($xhprof_runs_impl, $run_id, $type, $threshold,
-                             $func, $source, $critical_path) {
+function xhprof_render_image(
+    $xhprof_runs_impl,
+    $run_id,
+    $type,
+    $threshold,
+    $func,
+    $source,
+    $critical_path
+) {
 
-  $content = xhprof_get_content_by_run($xhprof_runs_impl, $run_id, $type,
-                                       $threshold,
-                                       $func, $source, $critical_path);
-  if (!$content) {
-    print "Error: either we can not find profile data for run_id ".$run_id
+    $content = xhprof_get_content_by_run(
+        $xhprof_runs_impl,
+        $run_id,
+        $type,
+        $threshold,
+        $func,
+        $source,
+        $critical_path
+    );
+    if (!$content) {
+        print "Error: either we can not find profile data for run_id ".$run_id
           ." or the threshold ".$threshold." is too small or you do not"
           ." have 'dot' image generation utility installed.";
-    exit();
-  }
+        exit();
+    }
 
-  xhprof_generate_mime_header($type, strlen($content));
-  echo $content;
+    xhprof_generate_mime_header($type, strlen($content));
+    echo $content;
 }

--- a/xhprof_lib/utils/common.php
+++ b/xhprof_lib/utils/common.php
@@ -5,8 +5,7 @@ function displayRuns($resultSet, $title = "")
     echo "<h1 class=\"runTitle\">$title</h1>\n";
     echo "<table id=\"box-table-a\" class=\"tablesorter\" summary=\"Stats\"><thead><tr><th>Timestamp</th><th>Cpu</th><th>Wall Time</th><th>Peak Memory Usage</th><th>URL</th><th>Simplified URL</th></tr></thead>";
     echo "<tbody>\n";
-    while ($row = XHProfRuns_Default::getNextAssoc($resultSet))
-    {
+    while ($row = XHProfRuns_Default::getNextAssoc($resultSet)) {
         $c_url = urlencode($row['c_url']);
         $url = urlencode($row['url']);
         $html['url'] = htmlentities($row['url'], ENT_QUOTES, 'UTF-8');
@@ -32,26 +31,21 @@ function printSeconds($time)
 {
     $suffix = "microsecond";
 
-    if ($time > 1000)
-    {
+    if ($time > 1000) {
         $time = $time / 1000;
         $suffix = "ms";
-
     }
 
-    if ($time > 1000)
-    {
+    if ($time > 1000) {
         $time = $time / 1000;
         $suffix = "s";
     }
 
-    if ($time > 60 && $suffix == "s")
-    {
+    if ($time > 60 && $suffix == "s") {
         $time = $time / 60;
         $suffix = "minutes!";
     }
     return sprintf("%.4f {$suffix}", $time);
-
 }
 
 
@@ -67,17 +61,16 @@ function showChart($rs, $flip = false)
         $arIDS = array();
         $arDateIDs = array();
 
-         while($row = XHProfRuns_Default::getNextAssoc($rs))
-        {
-            $date[] = "'" . date("Y-m-d", $row['timestamp']) . "'" ;
+    while ($row = XHProfRuns_Default::getNextAssoc($rs)) {
+        $date[] = "'" . date("Y-m-d", $row['timestamp']) . "'" ;
 
-            $arCPU[] = $row['cpu'];
-            $arWT[] = $row['wt'];
-            $arPEAK[] = $row['pmu'];
-            $arIDS[] = $row['id'];
+        $arCPU[] = $row['cpu'];
+        $arWT[] = $row['wt'];
+        $arPEAK[] = $row['pmu'];
+        $arIDS[] = $row['id'];
 
-            $arDateIDs[] =  "'" . date("Y-m-d", $row['timestamp']) . " <br/> " . $row['id'] . "'";
-        }
+        $arDateIDs[] =  "'" . date("Y-m-d", $row['timestamp']) . " <br/> " . $row['id'] . "'";
+    }
 
         $date = $flip ? array_reverse($date) : $date;
         $arCPU = $flip ? array_reverse($arCPU) : $arCPU;
@@ -95,33 +88,28 @@ function showChart($rs, $flip = false)
 
 
     ob_start();
-      require ("../xhprof_lib/templates/chart.phtml");
+      require("../xhprof_lib/templates/chart.phtml");
       $stuff = ob_get_contents();
     ob_end_clean();
-   return array($stuff, "<div id=\"container\" style=\"width: 1000px; height: 500px; margin: 0 auto\"></div>");
+    return array($stuff, "<div id=\"container\" style=\"width: 1000px; height: 500px; margin: 0 auto\"></div>");
 }
 
 
 
 function getFilter($filterName)
 {
-    if (isset($_GET[$filterName]))
-    {
-      if ($_GET[$filterName] == "None")
-      {
-        $serverFilter = null;
-        setcookie($filterName, null, 0);
-      }else
-      {
-        setcookie($filterName, $_GET[$filterName], (time() + 60 * 60));
-        $serverFilter = $_GET[$filterName];
-      }
-    }elseif(isset($_COOKIE[$filterName]))
-    {
+    if (isset($_GET[$filterName])) {
+        if ($_GET[$filterName] == "None") {
+            $serverFilter = null;
+            setcookie($filterName, null, 0);
+        } else {
+            setcookie($filterName, $_GET[$filterName], (time() + 60 * 60));
+            $serverFilter = $_GET[$filterName];
+        }
+    } elseif (isset($_COOKIE[$filterName])) {
         $serverFilter = $_COOKIE[$filterName];
-    }else
-    {
-      $serverFilter = null;
+    } else {
+        $serverFilter = null;
     }
     return $serverFilter;
 }

--- a/xhprof_lib/utils/xhprof_lib.php
+++ b/xhprof_lib/utils/xhprof_lib.php
@@ -19,8 +19,9 @@
 // Do not add any display specific code here.
 //
 
-function xhprof_error($message) {
-  error_log($message);
+function xhprof_error($message)
+{
+    error_log($message);
 }
 
 /*
@@ -29,16 +30,17 @@ function xhprof_error($message) {
  *
  * @author Kannan
  */
-function xhprof_get_possible_metrics() {
- static $possible_metrics =
-   array("wt" => array("Wall", "microsecs", "walltime" ),
+function xhprof_get_possible_metrics()
+{
+    static $possible_metrics =
+    array("wt" => array("Wall", "microsecs", "walltime" ),
          "ut" => array("User", "microsecs", "user cpu time" ),
          "st" => array("Sys", "microsecs", "system cpu time"),
          "cpu" => array("Cpu", "microsecs", "cpu time"),
          "mu" => array("MUse", "bytes", "memory usage"),
          "pmu" => array("PMUse", "bytes", "peak memory usage"),
          "samples" => array("Samples", "samples", "cpu time"));
- return $possible_metrics;
+    return $possible_metrics;
 }
 
 /*
@@ -46,21 +48,22 @@ function xhprof_get_possible_metrics() {
  *
  * @author Kannan
  */
-function xhprof_get_metrics($xhprof_data) {
+function xhprof_get_metrics($xhprof_data)
+{
 
   // get list of valid metrics
-  $possible_metrics = xhprof_get_possible_metrics();
+    $possible_metrics = xhprof_get_possible_metrics();
 
   // return those that are present in the raw data.
   // We'll just look at the root of the subtree for this.
-  $metrics = array();
-  foreach ($possible_metrics as $metric => $desc) {
-    if (isset($xhprof_data["main()"][$metric])) {
-      $metrics[] = $metric;
+    $metrics = array();
+    foreach ($possible_metrics as $metric => $desc) {
+        if (isset($xhprof_data["main()"][$metric])) {
+            $metrics[] = $metric;
+        }
     }
-  }
 
-  return $metrics;
+    return $metrics;
 }
 
 /**
@@ -69,15 +72,16 @@ function xhprof_get_metrics($xhprof_data) {
  *
  * @author Kannan
  */
-function xhprof_parse_parent_child($parent_child) {
-  $ret = explode("==>", $parent_child);
+function xhprof_parse_parent_child($parent_child)
+{
+    $ret = explode("==>", $parent_child);
 
   // Return if both parent and child are set
-  if (isset($ret[1])) {
-    return $ret;
-  }
+    if (isset($ret[1])) {
+        return $ret;
+    }
 
-  return array(null, $ret[0]);
+    return array(null, $ret[0]);
 }
 
 /**
@@ -86,12 +90,13 @@ function xhprof_parse_parent_child($parent_child) {
  *
  * @author Kannan
  */
-function xhprof_build_parent_child_key($parent, $child) {
-  if ($parent) {
-    return $parent . "==>" . $child;
-  } else {
-    return $child;
-  }
+function xhprof_build_parent_child_key($parent, $child)
+{
+    if ($parent) {
+        return $parent . "==>" . $child;
+    } else {
+        return $child;
+    }
 }
 
 
@@ -107,40 +112,41 @@ function xhprof_build_parent_child_key($parent, $child) {
  *
  *  @author Kannan
  */
-function xhprof_valid_run($run_id, $raw_data) {
+function xhprof_valid_run($run_id, $raw_data)
+{
 
-  $main_info = $raw_data["main()"];
-  if (empty($main_info)) {
-    xhprof_error("XHProf: main() missing in raw data for Run ID: $run_id");
-    return false;
-  }
+    $main_info = $raw_data["main()"];
+    if (empty($main_info)) {
+        xhprof_error("XHProf: main() missing in raw data for Run ID: $run_id");
+        return false;
+    }
 
   // raw data should contain either wall time or samples information...
-  if (isset($main_info["wt"])) {
-    $metric = "wt";
-  } else if (isset($main_info["samples"])) {
-    $metric = "samples";
-  } else {
-    xhprof_error("XHProf: Wall Time information missing from Run ID: $run_id");
-    return false;
-  }
-
-  foreach ($raw_data as $info) {
-    $val = $info[$metric];
-
-    // basic sanity checks...
-    if ($val < 0) {
-      xhprof_error("XHProf: $metric should not be negative: Run ID $run_id"
-                   . serialize($info));
-      return false;
+    if (isset($main_info["wt"])) {
+        $metric = "wt";
+    } elseif (isset($main_info["samples"])) {
+        $metric = "samples";
+    } else {
+        xhprof_error("XHProf: Wall Time information missing from Run ID: $run_id");
+        return false;
     }
-    if ($val > (86400000000)) {
-      xhprof_error("XHProf: $metric > 1 day found in Run ID: $run_id "
+
+    foreach ($raw_data as $info) {
+        $val = $info[$metric];
+
+        // basic sanity checks...
+        if ($val < 0) {
+            xhprof_error("XHProf: $metric should not be negative: Run ID $run_id"
                    . serialize($info));
-      return false;
+            return false;
+        }
+        if ($val > (86400000000)) {
+            xhprof_error("XHProf: $metric > 1 day found in Run ID: $run_id "
+                   . serialize($info));
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 
@@ -161,25 +167,26 @@ function xhprof_valid_run($run_id, $raw_data) {
  *
  * @author Kannan
  */
-function xhprof_trim_run($raw_data, $functions_to_keep) {
+function xhprof_trim_run($raw_data, $functions_to_keep)
+{
 
   // convert list of functions to a hash with function as the key
-  $function_map = array_fill_keys($functions_to_keep, 1);
+    $function_map = array_fill_keys($functions_to_keep, 1);
 
   // always keep main() as well so that overall totals can still
   // be computed if need be.
-  $function_map['main()'] = 1;
+    $function_map['main()'] = 1;
 
-  $new_raw_data = array();
-  foreach ($raw_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
+    $new_raw_data = array();
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
 
-    if (isset($function_map[$parent]) || isset($function_map[$child])) {
-      $new_raw_data[$parent_child] = $info;
+        if (isset($function_map[$parent]) || isset($function_map[$child])) {
+            $new_raw_data[$parent_child] = $info;
+        }
     }
-  }
 
-  return $new_raw_data;
+    return $new_raw_data;
 }
 
 /**
@@ -189,25 +196,26 @@ function xhprof_trim_run($raw_data, $functions_to_keep) {
  *
  * @author Kannan
  */
-function xhprof_normalize_metrics($raw_data, $num_runs) {
+function xhprof_normalize_metrics($raw_data, $num_runs)
+{
 
-  if (empty($raw_data) || ($num_runs == 0)) {
-    return $raw_data;
-  }
-
-  $raw_data_total = array();
-
-  if (isset($raw_data["==>main()"]) && isset($raw_data["main()"])) {
-    xhprof_error("XHProf Error: both ==>main() and main() set in raw data...");
-  }
-
-  foreach ($raw_data as $parent_child => $info) {
-    foreach ($info as $metric => $value) {
-      $raw_data_total[$parent_child][$metric] = ($value / $num_runs);
+    if (empty($raw_data) || ($num_runs == 0)) {
+        return $raw_data;
     }
-  }
 
-  return $raw_data_total;
+    $raw_data_total = array();
+
+    if (isset($raw_data["==>main()"]) && isset($raw_data["main()"])) {
+        xhprof_error("XHProf Error: both ==>main() and main() set in raw data...");
+    }
+
+    foreach ($raw_data as $parent_child => $info) {
+        foreach ($info as $metric => $value) {
+            $raw_data_total[$parent_child][$metric] = ($value / $num_runs);
+        }
+    }
+
+    return $raw_data_total;
 }
 
 
@@ -241,121 +249,130 @@ function xhprof_normalize_metrics($raw_data, $num_runs) {
  *
  *  @author Kannan
  */
-function xhprof_aggregate_runs($xhprof_runs_impl, $runs,
-                               $wts, $source="phprof",
-                               $use_script_name=false) {
+function xhprof_aggregate_runs(
+    $xhprof_runs_impl,
+    $runs,
+    $wts,
+    $source = "phprof",
+    $use_script_name = false
+) {
 
-  $raw_data_total = null;
-  $raw_data       = null;
-  $metrics        = array();
+    $raw_data_total = null;
+    $raw_data       = null;
+    $metrics        = array();
 
-  $run_count = count($runs);
-  $wts_count = count($wts);
+    $run_count = count($runs);
+    $wts_count = count($wts);
 
-  if (($run_count == 0) ||
+    if (($run_count == 0) ||
       (($wts_count > 0) && ($run_count != $wts_count))) {
-    return array('description' => 'Invalid input..',
+        return array('description' => 'Invalid input..',
                  'raw'  => null);
-  }
-
-  $bad_runs = array();
-  foreach($runs as $idx => $run_id) {
-
-    $raw_data = $xhprof_runs_impl->get_run($run_id, $source, $description);
-
-    // use the first run to derive what metrics to aggregate on.
-    if ($idx == 0) {
-      foreach ($raw_data["main()"] as $metric => $val) {
-        if ($metric != "pmu") {
-          // for now, just to keep data size small, skip "peak" memory usage
-          // data while aggregating.
-          // The "regular" memory usage data will still be tracked.
-          if (isset($val)) {
-            $metrics[] = $metric;
-          }
-        }
-      }
     }
 
-    if (!xhprof_valid_run($run_id, $raw_data)) {
-      $bad_runs[] = $run_id;
-      continue;
+    $bad_runs = array();
+    foreach ($runs as $idx => $run_id) {
+        $raw_data = $xhprof_runs_impl->get_run($run_id, $source, $description);
+
+        // use the first run to derive what metrics to aggregate on.
+        if ($idx == 0) {
+            foreach ($raw_data["main()"] as $metric => $val) {
+                if ($metric != "pmu") {
+                    // for now, just to keep data size small, skip "peak" memory usage
+                    // data while aggregating.
+                    // The "regular" memory usage data will still be tracked.
+                    if (isset($val)) {
+                        $metrics[] = $metric;
+                    }
+                }
+            }
+        }
+
+        if (!xhprof_valid_run($run_id, $raw_data)) {
+            $bad_runs[] = $run_id;
+            continue;
+        }
+
+        if ($use_script_name) {
+            $page = $description;
+
+            // create a fake function '__script::$page', and have and edge from
+            // main() to '__script::$page'. We will also need edges to transfer
+            // all edges originating from main() to now originate from
+            // '__script::$page' to all function called from main().
+            //
+            // We also weight main() ever so slightly higher so that
+            // it shows up above the new entry in reports sorted by
+            // inclusive metrics or call counts.
+            if ($page) {
+                foreach ($raw_data["main()"] as $metric => $val) {
+                    $fake_edge[$metric] = $val;
+                    $new_main[$metric]  = $val + 0.00001;
+                }
+                $raw_data["main()"] = $new_main;
+                $raw_data[xhprof_build_parent_child_key(
+                    "main()",
+                    "__script::$page"
+                )]
+                  = $fake_edge;
+            } else {
+                $use_script_name = false;
+            }
+        }
+
+        // if no weights specified, use 1 as the default weightage..
+        $wt = ($wts_count == 0) ? 1 : $wts[$idx];
+
+        // aggregate $raw_data into $raw_data_total with appropriate weight ($wt)
+        foreach ($raw_data as $parent_child => $info) {
+            if ($use_script_name) {
+                // if this is an old edge originating from main(), it now
+                // needs to be from '__script::$page'
+                if (substr($parent_child, 0, 9) == "main()==>") {
+                    $child =substr($parent_child, 9);
+                    // ignore the newly added edge from main()
+                    if (substr($child, 0, 10) != "__script::") {
+                        $parent_child = xhprof_build_parent_child_key(
+                            "__script::$page",
+                            $child
+                        );
+                    }
+                }
+            }
+
+            if (!isset($raw_data_total[$parent_child])) {
+                foreach ($metrics as $metric) {
+                    $raw_data_total[$parent_child][$metric] = ($wt * $info[$metric]);
+                }
+            } else {
+                foreach ($metrics as $metric) {
+                    $raw_data_total[$parent_child][$metric] += ($wt * $info[$metric]);
+                }
+            }
+        }
     }
 
-    if ($use_script_name) {
-      $page = $description;
+    $runs_string = implode(",", $runs);
 
-      // create a fake function '__script::$page', and have and edge from
-      // main() to '__script::$page'. We will also need edges to transfer
-      // all edges originating from main() to now originate from
-      // '__script::$page' to all function called from main().
-      //
-      // We also weight main() ever so slightly higher so that
-      // it shows up above the new entry in reports sorted by
-      // inclusive metrics or call counts.
-      if ($page) {
-        foreach($raw_data["main()"] as $metric => $val) {
-          $fake_edge[$metric] = $val;
-          $new_main[$metric]  = $val + 0.00001;
-        }
-        $raw_data["main()"] = $new_main;
-        $raw_data[xhprof_build_parent_child_key("main()",
-                                                "__script::$page")]
-          = $fake_edge;
-      } else {
-        $use_script_name = false;
-      }
+    if (isset($wts)) {
+        $wts_string  = "in the ratio (" . implode(":", $wts) . ")";
+        $normalization_count = array_sum($wts);
+    } else {
+        $wts_string = "";
+        $normalization_count = $run_count;
     }
 
-    // if no weights specified, use 1 as the default weightage..
-    $wt = ($wts_count == 0) ? 1 : $wts[$idx];
+    $run_count = $run_count - count($bad_runs);
 
-    // aggregate $raw_data into $raw_data_total with appropriate weight ($wt)
-    foreach ($raw_data as $parent_child => $info) {
-      if ($use_script_name) {
-        // if this is an old edge originating from main(), it now
-        // needs to be from '__script::$page'
-        if (substr($parent_child, 0, 9) == "main()==>") {
-          $child =substr($parent_child, 9);
-          // ignore the newly added edge from main()
-          if (substr($child, 0, 10) != "__script::") {
-            $parent_child = xhprof_build_parent_child_key("__script::$page",
-                                                          $child);
-          }
-        }
-      }
-
-      if (!isset($raw_data_total[$parent_child])) {
-        foreach ($metrics as $metric) {
-          $raw_data_total[$parent_child][$metric] = ($wt * $info[$metric]);
-        }
-      } else {
-        foreach ($metrics as $metric) {
-          $raw_data_total[$parent_child][$metric] += ($wt * $info[$metric]);
-        }
-      }
-    }
-  }
-
-  $runs_string = implode(",", $runs);
-
-  if (isset($wts)) {
-    $wts_string  = "in the ratio (" . implode(":", $wts) . ")";
-    $normalization_count = array_sum($wts);
-  } else {
-    $wts_string = "";
-    $normalization_count = $run_count;
-  }
-
-  $run_count = $run_count - count($bad_runs);
-
-  $data['description'] = "Aggregated Report for $run_count runs: ".
+    $data['description'] = "Aggregated Report for $run_count runs: ".
                          "$runs_string $wts_string\n";
-  $data['raw'] = xhprof_normalize_metrics($raw_data_total,
-                                          $normalization_count);
-  $data['bad_runs'] = $bad_runs;
+    $data['raw'] = xhprof_normalize_metrics(
+        $raw_data_total,
+        $normalization_count
+    );
+    $data['bad_runs'] = $bad_runs;
 
-  return $data;
+    return $data;
 }
 
 
@@ -375,13 +392,14 @@ function xhprof_aggregate_runs($xhprof_runs_impl, $runs,
  *
  * @author Kannan Muthukkaruppan
  */
-function xhprof_compute_flat_info($raw_data, &$overall_totals) {
+function xhprof_compute_flat_info($raw_data, &$overall_totals)
+{
 
-  global $display_calls;
+    global $display_calls;
 
-  $metrics = xhprof_get_metrics($raw_data);
+    $metrics = xhprof_get_metrics($raw_data);
 
-  $overall_totals = array( "ct" => 0,
+    $overall_totals = array( "ct" => 0,
                            "wt" => 0,
                            "ut" => 0,
                            "st" => 0,
@@ -392,43 +410,43 @@ function xhprof_compute_flat_info($raw_data, &$overall_totals) {
                            );
 
   // compute inclusive times for each function
-  $symbol_tab = xhprof_compute_inclusive_times($raw_data);
+    $symbol_tab = xhprof_compute_inclusive_times($raw_data);
 
   /* total metric value is the metric value for "main()" */
-  foreach ($metrics as $metric) {
-    $overall_totals[$metric] = $symbol_tab["main()"][$metric];
-  }
+    foreach ($metrics as $metric) {
+        $overall_totals[$metric] = $symbol_tab["main()"][$metric];
+    }
 
   /*
    * initialize exclusive (self) metric value to inclusive metric value
    * to start with.
    * In the same pass, also add up the total number of function calls.
    */
-  foreach ($symbol_tab as $symbol => $info) {
-    foreach ($metrics as $metric) {
-      $symbol_tab[$symbol]["excl_" . $metric] = $symbol_tab[$symbol][$metric];
+    foreach ($symbol_tab as $symbol => $info) {
+        foreach ($metrics as $metric) {
+            $symbol_tab[$symbol]["excl_" . $metric] = $symbol_tab[$symbol][$metric];
+        }
+        if ($display_calls) {
+            /* keep track of total number of calls */
+            $overall_totals["ct"] += $info["ct"];
+        }
     }
-    if ($display_calls) {
-      /* keep track of total number of calls */
-      $overall_totals["ct"] += $info["ct"];
-    }
-  }
 
   /* adjust exclusive times by deducting inclusive time of children */
-  foreach ($raw_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
 
-    if ($parent) {
-      foreach ($metrics as $metric) {
-        // make sure the parent exists hasn't been pruned.
-        if (isset($symbol_tab[$parent])) {
-          $symbol_tab[$parent]["excl_" . $metric] -= $info[$metric];
+        if ($parent) {
+            foreach ($metrics as $metric) {
+                // make sure the parent exists hasn't been pruned.
+                if (isset($symbol_tab[$parent])) {
+                    $symbol_tab[$parent]["excl_" . $metric] -= $info[$metric];
+                }
+            }
         }
-      }
     }
-  }
 
-  return $symbol_tab;
+    return $symbol_tab;
 }
 
 /**
@@ -437,40 +455,39 @@ function xhprof_compute_flat_info($raw_data, &$overall_totals) {
  *
  * @author Kannan
  */
-function xhprof_compute_diff($xhprof_data1, $xhprof_data2) {
-  global $display_calls;
+function xhprof_compute_diff($xhprof_data1, $xhprof_data2)
+{
+    global $display_calls;
 
   // use the second run to decide what metrics we will do the diff on
-  $metrics = xhprof_get_metrics($xhprof_data2);
+    $metrics = xhprof_get_metrics($xhprof_data2);
 
-  $xhprof_delta = $xhprof_data2;
+    $xhprof_delta = $xhprof_data2;
 
-  foreach ($xhprof_data1 as $parent_child => $info) {
+    foreach ($xhprof_data1 as $parent_child => $info) {
+        if (!isset($xhprof_delta[$parent_child])) {
+            // this pc combination was not present in run1;
+            // initialize all values to zero.
+            if ($display_calls) {
+                $xhprof_delta[$parent_child] = array("ct" => 0);
+            } else {
+                $xhprof_delta[$parent_child] = array();
+            }
+            foreach ($metrics as $metric) {
+                $xhprof_delta[$parent_child][$metric] = 0;
+            }
+        }
 
-    if (!isset($xhprof_delta[$parent_child])) {
+        if ($display_calls) {
+            $xhprof_delta[$parent_child]["ct"] -= $info["ct"];
+        }
 
-      // this pc combination was not present in run1;
-      // initialize all values to zero.
-      if ($display_calls) {
-        $xhprof_delta[$parent_child] = array("ct" => 0);
-      } else {
-        $xhprof_delta[$parent_child] = array();
-      }
-      foreach ($metrics as $metric) {
-        $xhprof_delta[$parent_child][$metric] = 0;
-      }
+        foreach ($metrics as $metric) {
+            $xhprof_delta[$parent_child][$metric] -= $info[$metric];
+        }
     }
 
-    if ($display_calls) {
-      $xhprof_delta[$parent_child]["ct"] -= $info["ct"];
-    }
-
-    foreach ($metrics as $metric) {
-      $xhprof_delta[$parent_child][$metric] -= $info[$metric];
-    }
-  }
-
-  return $xhprof_delta;
+    return $xhprof_delta;
 }
 
 
@@ -488,56 +505,55 @@ function xhprof_compute_diff($xhprof_data1, $xhprof_data2) {
  *
  * @author Kannan
  */
-function xhprof_compute_inclusive_times($raw_data) {
-  global $display_calls;
+function xhprof_compute_inclusive_times($raw_data)
+{
+    global $display_calls;
 
-  $metrics = xhprof_get_metrics($raw_data);
+    $metrics = xhprof_get_metrics($raw_data);
 
-  $symbol_tab = array();
+    $symbol_tab = array();
 
   /*
    * First compute inclusive time for each function and total
    * call count for each function across all parents the
    * function is called from.
    */
-  foreach ($raw_data as $parent_child => $info) {
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
 
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
+        if ($parent == $child) {
+            /*
+             * XHProf PHP extension should never trigger this situation any more.
+             * Recursion is handled in the XHProf PHP extension by giving nested
+             * calls a unique recursion-depth appended name (for example, foo@1).
+             */
+            xhprof_error("Error in Raw Data: parent & child are both: $parent");
+            return;
+        }
 
-    if ($parent == $child) {
-      /*
-       * XHProf PHP extension should never trigger this situation any more.
-       * Recursion is handled in the XHProf PHP extension by giving nested
-       * calls a unique recursion-depth appended name (for example, foo@1).
-       */
-      xhprof_error("Error in Raw Data: parent & child are both: $parent");
-      return;
+        if (!isset($symbol_tab[$child])) {
+            if ($display_calls) {
+                $symbol_tab[$child] = array("ct" => $info["ct"]);
+            } else {
+                $symbol_tab[$child] = array();
+            }
+            foreach ($metrics as $metric) {
+                $symbol_tab[$child][$metric] = $info[$metric];
+            }
+        } else {
+            if ($display_calls) {
+                /* increment call count for this child */
+                $symbol_tab[$child]["ct"] += $info["ct"];
+            }
+
+            /* update inclusive times/metric for this child  */
+            foreach ($metrics as $metric) {
+                $symbol_tab[$child][$metric] += $info[$metric];
+            }
+        }
     }
 
-    if (!isset($symbol_tab[$child])) {
-
-      if ($display_calls) {
-        $symbol_tab[$child] = array("ct" => $info["ct"]);
-      } else {
-        $symbol_tab[$child] = array();
-      }
-      foreach ($metrics as $metric) {
-        $symbol_tab[$child][$metric] = $info[$metric];
-      }
-    } else {
-      if ($display_calls) {
-        /* increment call count for this child */
-        $symbol_tab[$child]["ct"] += $info["ct"];
-      }
-
-      /* update inclusive times/metric for this child  */
-      foreach ($metrics as $metric) {
-        $symbol_tab[$child][$metric] += $info[$metric];
-      }
-    }
-  }
-
-  return $symbol_tab;
+    return $symbol_tab;
 }
 
 
@@ -560,68 +576,67 @@ function xhprof_compute_inclusive_times($raw_data) {
  *
  *  @author Kannan
  */
-function xhprof_prune_run($raw_data, $prune_percent) {
+function xhprof_prune_run($raw_data, $prune_percent)
+{
 
-  $main_info = $raw_data["main()"];
-  if (empty($main_info)) {
-    xhprof_error("XHProf: main() missing in raw data");
-    return false;
-  }
+    $main_info = $raw_data["main()"];
+    if (empty($main_info)) {
+        xhprof_error("XHProf: main() missing in raw data");
+        return false;
+    }
 
   // raw data should contain either wall time or samples information...
-  if (isset($main_info["wt"])) {
-    $prune_metric = "wt";
-  } else if (isset($main_info["samples"])) {
-    $prune_metric = "samples";
-  } else {
-    xhprof_error("XHProf: for main() we must have either wt "
+    if (isset($main_info["wt"])) {
+        $prune_metric = "wt";
+    } elseif (isset($main_info["samples"])) {
+        $prune_metric = "samples";
+    } else {
+        xhprof_error("XHProf: for main() we must have either wt "
                  ."or samples attribute set");
-    return false;
-  }
+        return false;
+    }
 
   // determine the metrics present in the raw data..
-  $metrics = array();
-  foreach ($main_info as $metric => $val) {
-    if (isset($val)) {
-      $metrics[] = $metric;
+    $metrics = array();
+    foreach ($main_info as $metric => $val) {
+        if (isset($val)) {
+            $metrics[] = $metric;
+        }
     }
-  }
 
-  $prune_threshold = (($main_info[$prune_metric] * $prune_percent) / 100.0);
+    $prune_threshold = (($main_info[$prune_metric] * $prune_percent) / 100.0);
 
-  init_metrics($raw_data, null, null, false);
-  $flat_info = xhprof_compute_inclusive_times($raw_data);
+    init_metrics($raw_data, null, null, false);
+    $flat_info = xhprof_compute_inclusive_times($raw_data);
 
-  foreach ($raw_data as $parent_child => $info) {
+    foreach ($raw_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
 
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
-
-    // is this child's overall total from all parents less than threshold?
-    if ($flat_info[$child][$prune_metric] < $prune_threshold) {
-      unset($raw_data[$parent_child]); // prune the edge
-    } else if ($parent &&
+        // is this child's overall total from all parents less than threshold?
+        if ($flat_info[$child][$prune_metric] < $prune_threshold) {
+            unset($raw_data[$parent_child]); // prune the edge
+        } elseif ($parent &&
                ($parent != "__pruned__()") &&
                ($flat_info[$parent][$prune_metric] < $prune_threshold)) {
+            // Parent's overall inclusive metric is less than a threshold.
+            // All edges to the parent node will get nuked, and this child will
+            // be a dangling child.
+            // So instead change its parent to be a special function __pruned__().
+            $pruned_edge = xhprof_build_parent_child_key("__pruned__()", $child);
 
-      // Parent's overall inclusive metric is less than a threshold.
-      // All edges to the parent node will get nuked, and this child will
-      // be a dangling child.
-      // So instead change its parent to be a special function __pruned__().
-      $pruned_edge = xhprof_build_parent_child_key("__pruned__()", $child);
+            if (isset($raw_data[$pruned_edge])) {
+                foreach ($metrics as $metric) {
+                    $raw_data[$pruned_edge][$metric]+=$raw_data[$parent_child][$metric];
+                }
+            } else {
+                  $raw_data[$pruned_edge] = $raw_data[$parent_child];
+            }
 
-      if (isset($raw_data[$pruned_edge])) {
-        foreach ($metrics as $metric) {
-          $raw_data[$pruned_edge][$metric]+=$raw_data[$parent_child][$metric];
+            unset($raw_data[$parent_child]); // prune the edge
         }
-      } else {
-        $raw_data[$pruned_edge] = $raw_data[$parent_child];
-      }
-
-      unset($raw_data[$parent_child]); // prune the edge
     }
-  }
 
-  return $raw_data;
+    return $raw_data;
 }
 
 
@@ -630,9 +645,10 @@ function xhprof_prune_run($raw_data, $prune_percent) {
  *
  * @author Kannan
  */
-function xhprof_array_set($arr, $k, $v) {
-  $arr[$k] = $v;
-  return $arr;
+function xhprof_array_set($arr, $k, $v)
+{
+    $arr[$k] = $v;
+    return $arr;
 }
 
 /**
@@ -640,18 +656,19 @@ function xhprof_array_set($arr, $k, $v) {
  *
  * @author Kannan
  */
-function xhprof_array_unset($arr, $k) {
-  unset($arr[$k]);
-  return $arr;
+function xhprof_array_unset($arr, $k)
+{
+    unset($arr[$k]);
+    return $arr;
 }
 
 /**
  * Type definitions for URL params
  */
 define('XHPROF_STRING_PARAM', 1);
-define('XHPROF_UINT_PARAM',   2);
-define('XHPROF_FLOAT_PARAM',  3);
-define('XHPROF_BOOL_PARAM',   4);
+define('XHPROF_UINT_PARAM', 2);
+define('XHPROF_FLOAT_PARAM', 3);
+define('XHPROF_BOOL_PARAM', 4);
 
 
 /**
@@ -663,14 +680,15 @@ define('XHPROF_BOOL_PARAM',   4);
  *
  * @author Kannan
  */
-function xhprof_get_param_helper($param) {
-  $val = null;
-  if (isset($_GET[$param]))
-    $val = $_GET[$param];
-  else if (isset($_POST[$param])) {
-    $val = $_POST[$param];
-  }
-  return $val;
+function xhprof_get_param_helper($param)
+{
+    $val = null;
+    if (isset($_GET[$param])) {
+        $val = $_GET[$param];
+    } elseif (isset($_POST[$param])) {
+        $val = $_POST[$param];
+    }
+    return $val;
 }
 
 /**
@@ -680,17 +698,19 @@ function xhprof_get_param_helper($param) {
  *
  * @author Kannan
  */
-function xhprof_get_string_param($param, $default = '') {
-  $val = xhprof_get_param_helper($param);
+function xhprof_get_string_param($param, $default = '')
+{
+    $val = xhprof_get_param_helper($param);
 
-  if ($val === null)
-    return $default;
+    if ($val === null) {
+        return $default;
+    }
 
-  if (get_magic_quotes_gpc() == 1) {
-    return stripslashes($val);
-  }
+    if (get_magic_quotes_gpc() == 1) {
+        return stripslashes($val);
+    }
 
-  return $val;
+    return $val;
 }
 
 /**
@@ -703,22 +723,24 @@ function xhprof_get_string_param($param, $default = '') {
  *
  * @author Kannan
  */
-function xhprof_get_uint_param($param, $default = 0) {
-  $val = xhprof_get_param_helper($param);
+function xhprof_get_uint_param($param, $default = 0)
+{
+    $val = xhprof_get_param_helper($param);
 
-  if ($val === null)
-    $val = $default;
+    if ($val === null) {
+        $val = $default;
+    }
 
   // trim leading/trailing whitespace
-  $val = trim($val);
+    $val = trim($val);
 
   // if it only contains digits, then ok..
-  if (ctype_digit($val)) {
-    return $val;
-  }
+    if (ctype_digit($val)) {
+        return $val;
+    }
 
-  xhprof_error("$param is $val. It must be an unsigned integer.");
-  return null;
+    xhprof_error("$param is $val. It must be an unsigned integer.");
+    return null;
 }
 
 
@@ -732,21 +754,24 @@ function xhprof_get_uint_param($param, $default = 0) {
  *
  * @author Kannan
  */
-function xhprof_get_float_param($param, $default = 0) {
-  $val = xhprof_get_param_helper($param);
+function xhprof_get_float_param($param, $default = 0)
+{
+    $val = xhprof_get_param_helper($param);
 
-  if ($val === null)
-    $val = $default;
+    if ($val === null) {
+        $val = $default;
+    }
 
   // trim leading/trailing whitespace
-  $val = trim($val);
+    $val = trim($val);
 
   // TBD: confirm the value is indeed a float.
-  if (true) // for now..
-    return (float)$val;
+    if (true) { // for now..
+        return (float)$val;
+    }
 
-  xhprof_error("$param is $val. It must be a float.");
-  return null;
+    xhprof_error("$param is $val. It must be a float.");
+    return null;
 }
 
 /**
@@ -759,37 +784,38 @@ function xhprof_get_float_param($param, $default = 0) {
  *
  * @author Kannan
  */
-function xhprof_get_bool_param($param, $default = false) {
-  $val = xhprof_get_param_helper($param);
+function xhprof_get_bool_param($param, $default = false)
+{
+    $val = xhprof_get_param_helper($param);
 
-  if ($val === null)
-    $val = $default;
+    if ($val === null) {
+        $val = $default;
+    }
 
   // trim leading/trailing whitespace
-  $val = trim($val);
+    $val = trim($val);
 
-  switch (strtolower($val)) {
-  case '0':
-  case '1':
-    $val = (bool)$val;
-    break;
-  case 'true':
-  case 'on':
-  case 'yes':
-    $val = true;
-    break;
-  case 'false':
-  case 'off':
-  case 'no':
-    $val = false;
-    break;
-  default:
-    xhprof_error("$param is $val. It must be a valid boolean string.");
-    return null;
-  }
+    switch (strtolower($val)) {
+        case '0':
+        case '1':
+            $val = (bool)$val;
+            break;
+        case 'true':
+        case 'on':
+        case 'yes':
+            $val = true;
+            break;
+        case 'false':
+        case 'off':
+        case 'no':
+            $val = false;
+            break;
+        default:
+            xhprof_error("$param is $val. It must be a valid boolean string.");
+            return null;
+    }
 
-  return $val;
-
+    return $val;
 }
 
 /**
@@ -811,31 +837,32 @@ function xhprof_get_bool_param($param, $default = false) {
  *                       used.
  * @author Kannan
  */
-function xhprof_param_init($params) {
+function xhprof_param_init($params)
+{
   /* Create variables specified in $params keys, init defaults */
-  foreach ($params as $k => $v) {
-    switch ($v[0]) {
-    case XHPROF_STRING_PARAM:
-      $p = xhprof_get_string_param($k, $v[1]);
-      break;
-    case XHPROF_UINT_PARAM:
-      $p = xhprof_get_uint_param($k, $v[1]);
-      break;
-    case XHPROF_FLOAT_PARAM:
-      $p = xhprof_get_float_param($k, $v[1]);
-      break;
-    case XHPROF_BOOL_PARAM:
-      $p = xhprof_get_bool_param($k, $v[1]);
-      break;
-    default:
-      xhprof_error("Invalid param type passed to xhprof_param_init: "
+    foreach ($params as $k => $v) {
+        switch ($v[0]) {
+            case XHPROF_STRING_PARAM:
+                $p = xhprof_get_string_param($k, $v[1]);
+                break;
+            case XHPROF_UINT_PARAM:
+                $p = xhprof_get_uint_param($k, $v[1]);
+                break;
+            case XHPROF_FLOAT_PARAM:
+                $p = xhprof_get_float_param($k, $v[1]);
+                break;
+            case XHPROF_BOOL_PARAM:
+                $p = xhprof_get_bool_param($k, $v[1]);
+                break;
+            default:
+                xhprof_error("Invalid param type passed to xhprof_param_init: "
                    . $v[0]);
-      exit();
-    }
+                exit();
+        }
 
-    // create a global variable using the parameter name.
-    $GLOBALS[$k] = $p;
-  }
+        // create a global variable using the parameter name.
+        $GLOBALS[$k] = $p;
+    }
 }
 
 
@@ -846,25 +873,25 @@ function xhprof_param_init($params) {
  *
  * @author Kannan
  */
-function xhprof_get_matching_functions($q, $xhprof_data) {
+function xhprof_get_matching_functions($q, $xhprof_data)
+{
 
-  $matches = array();
+    $matches = array();
 
-  foreach ($xhprof_data as $parent_child => $info) {
-    list($parent, $child) = xhprof_parse_parent_child($parent_child);
-    if (stripos($parent, $q) !== false) {
-      $matches[$parent] = 1;
+    foreach ($xhprof_data as $parent_child => $info) {
+        list($parent, $child) = xhprof_parse_parent_child($parent_child);
+        if (stripos($parent, $q) !== false) {
+            $matches[$parent] = 1;
+        }
+        if (stripos($child, $q) !== false) {
+            $matches[$child] = 1;
+        }
     }
-    if (stripos($child, $q) !== false) {
-      $matches[$child] = 1;
-    }
-  }
 
-  $res = array_keys($matches);
+    $res = array_keys($matches);
 
   // sort it so the answers are in some reliable order...
-  asort($res);
+    asort($res);
 
-  return ($res);
+    return ($res);
 }
-

--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -29,7 +29,8 @@
  *
  * @author Kannan
  */
-interface iXHProfRuns {
+interface iXHProfRuns
+{
 
   /**
    * Returns XHProf data given a run id ($run) of a given
@@ -38,7 +39,7 @@ interface iXHProfRuns {
    * Also, a brief description of the run is returned via the
    * $run_desc out parameter.
    */
-  public function get_run($run_id, $type, &$run_desc);
+    public function get_run($run_id, $type, &$run_desc);
 
   /**
    * Save XHProf data for a profiler run of specified type
@@ -52,7 +53,7 @@ interface iXHProfRuns {
    * Returns the run id for the saved XHProf run.
    *
    */
-  public function save_run($xhprof_data, $type, $run_id = null);
+    public function save_run($xhprof_data, $type, $run_id = null);
 }
 
 
@@ -64,47 +65,48 @@ interface iXHProfRuns {
  * the data, it also stores additional information outside the run
  * itself (beyond simply the run id) to make comparisons and run
  * location easier
- * 
+ *
  * @author Kannan
  * @author Paul Reinheimer (http://blog.preinheimer.com)
  */
-class XHProfRuns_Default implements iXHProfRuns {
+class XHProfRuns_Default implements iXHProfRuns
+{
 
-  private $dir = '';
-  public $prefix = 't11_';
-  public $run_details = null;
+    private $dir = '';
+    public $prefix = 't11_';
+    public $run_details = null;
   /**
-   * 
+   *
    * @var Db_Abstract
    */
-  protected $db;
+    protected $db;
 
-  public function __construct($dir = null) 
-  {
-    $this->db();
-  }
+    public function __construct($dir = null)
+    {
+        $this->db();
+    }
 
-  protected function db()
-  {
-	global $_xhprof;
-	require_once XHPROF_LIB_ROOT.'/utils/Db/'.$_xhprof['dbadapter'].'.php';
-	
-    $class = self::getDbClass();
-    $this->db = new $class($_xhprof);
-    $this->db->connect();
-  }
+    protected function db()
+    {
+        global $_xhprof;
+        require_once XHPROF_LIB_ROOT.'/utils/Db/'.$_xhprof['dbadapter'].'.php';
+    
+        $class = self::getDbClass();
+        $this->db = new $class($_xhprof);
+        $this->db->connect();
+    }
   
-  public static function getDbClass()
-  {
-      global $_xhprof;
+    public static function getDbClass()
+    {
+        global $_xhprof;
       
-      $class = 'Db_'.$_xhprof['dbadapter'];
-      return $class;
-  }
+        $class = 'Db_'.$_xhprof['dbadapter'];
+        return $class;
+    }
   
   /**
   * When setting the `id` column, consider the length of the prefix you're specifying in $this->prefix
-  * 
+  *
   *
 CREATE TABLE `details` (
   `id` char(17) NOT NULL,
@@ -130,91 +132,77 @@ CREATE TABLE `details` (
   KEY `pmu` (`pmu`),
   KEY `timestamp` (`timestamp`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-  
+
 */
 
     
-  private function gen_run_id($type) 
-  {
-    return uniqid();
-  }
+    private function gen_run_id($type)
+    {
+        return uniqid();
+    }
   
   /**
   * This function gets runs based on passed parameters, column data as key, value as the value. Values
   * are escaped automatically. You may also pass limit, order by, group by, or "where" to add those values,
-  * all of which are used as is, no escaping. 
-  * 
+  * all of which are used as is, no escaping.
+  *
   * @param array $stats Criteria by which to select columns
   * @return resource
   */
-  public function getRuns($stats)
-  {
-      if (isset($stats['select']))
-      {
-        $query = "SELECT {$stats['select']} FROM `details` ";  
-      }else
-      {
-        $query = "SELECT * FROM `details` ";
-      }
+    public function getRuns($stats)
+    {
+        if (isset($stats['select'])) {
+            $query = "SELECT {$stats['select']} FROM `details` ";
+        } else {
+            $query = "SELECT * FROM `details` ";
+        }
       
-      $skippers = array("limit", "order by", "group by", "where", "select");
-      $hasWhere = false;
+          $skippers = array("limit", "order by", "group by", "where", "select");
+          $hasWhere = false;
       
-      foreach($stats AS $column => $value)
-      {
+        foreach ($stats as $column => $value) {
+            if (in_array($column, $skippers)) {
+                continue;
+            }
+            if ($hasWhere === false) {
+                $query .= " WHERE ";
+                $hasWhere = true;
+            } elseif ($hasWhere === true) {
+                $query .= "AND ";
+            }
+            if (strlen($value) == 0) {
+                $query .= $column;
+            }
           
-          if (in_array($column, $skippers))
-          {
-              continue;
-          }
-          if ($hasWhere === false)
-          {
-              $query .= " WHERE ";
-              $hasWhere = true;
-          }elseif($hasWhere === true)
-          {
-            $query .= "AND ";
-          }
-          if (strlen($value) == 0)
-          {
-              $query .= $column;
-          }
-          
-          $value = $this->db->escape($value);
-          $query .= " `$column` = '$value' ";
-      }
+              $value = $this->db->escape($value);
+              $query .= " `$column` = '$value' ";
+        }
       
-      if (isset($stats['where']))
-      {
-          if ($hasWhere === false)
-          {
-              $query .= " WHERE ";
-              $hasWhere = true;
-          }else
-          {
-            $query .= " AND ";
-          }
-          $query .= $stats['where'];
-      }
+        if (isset($stats['where'])) {
+            if ($hasWhere === false) {
+                $query .= " WHERE ";
+                $hasWhere = true;
+            } else {
+                $query .= " AND ";
+            }
+            $query .= $stats['where'];
+        }
       
-      if (isset($stats['group by']))
-      {
-          $query .= " GROUP BY `{$stats['group by']}` ";
-      }
+        if (isset($stats['group by'])) {
+            $query .= " GROUP BY `{$stats['group by']}` ";
+        }
       
-      if (isset($stats['order by']))
-      {
-          $query .= " ORDER BY `{$stats['order by']}` DESC";
-      }
+        if (isset($stats['order by'])) {
+            $query .= " ORDER BY `{$stats['order by']}` DESC";
+        }
       
-      if (isset($stats['limit']))
-      {
-          $query .= " LIMIT {$stats['limit']} ";
-      }
+        if (isset($stats['limit'])) {
+            $query .= " LIMIT {$stats['limit']} ";
+        }
       
-      $resultSet = $this->db->query($query);
-      return $resultSet;
-  }
+          $resultSet = $this->db->query($query);
+          return $resultSet;
+    }
   
   /**
    * Obtains the pages that have been the hardest hit over the past N days, utalizing the getRuns() method.
@@ -222,164 +210,162 @@ CREATE TABLE `details` (
    * @param array $criteria An associative array containing, at minimum, type, days, and limit
    * @return resource The result set reprsenting the results of the query
    */
-  public function getHardHit($criteria)
-  {
-    //call thing to get runs
-    $criteria['select'] = "distinct(`{$criteria['type']}`), count(`{$criteria['type']}`) AS `count` , sum(`wt`) as total_wall, avg(`wt`) as avg_wall";
-    unset($criteria['type']);
-    $criteria['where'] = $this->db->dateSub($criteria['days']) . " <= `timestamp`";
-    unset($criteria['days']);
-    $criteria['group by'] = "url";
-    $criteria['order by'] = "count";
-    $resultSet = $this->getRuns($criteria);
+    public function getHardHit($criteria)
+    {
+        //call thing to get runs
+        $criteria['select'] = "distinct(`{$criteria['type']}`), count(`{$criteria['type']}`) AS `count` , sum(`wt`) as total_wall, avg(`wt`) as avg_wall";
+        unset($criteria['type']);
+        $criteria['where'] = $this->db->dateSub($criteria['days']) . " <= `timestamp`";
+        unset($criteria['days']);
+        $criteria['group by'] = "url";
+        $criteria['order by'] = "count";
+        $resultSet = $this->getRuns($criteria);
     
-    return $resultSet;
-  }
+        return $resultSet;
+    }
   
-  public function getDistinct($data)
-  {
-	$sql['column'] = $this->db->escape($data['column']);
-	$query = "SELECT DISTINCT(`{$sql['column']}`) FROM `details`";
-	$rs = $this->db->query($query);
-	return $rs;
-  }
+    public function getDistinct($data)
+    {
+        $sql['column'] = $this->db->escape($data['column']);
+        $query = "SELECT DISTINCT(`{$sql['column']}`) FROM `details`";
+        $rs = $this->db->query($query);
+        return $rs;
+    }
   
-  public static function getNextAssoc($resultSet)
-  {
-    $class = self::getDbClass();
-    return $class::getNextAssoc($resultSet);
-  }
+    public static function getNextAssoc($resultSet)
+    {
+        $class = self::getDbClass();
+        return $class::getNextAssoc($resultSet);
+    }
   
   /**
-  * Retreives a run from the database, 
-  * 
+  * Retreives a run from the database,
+  *
   * @param string $run_id unique identifier for the run being requested
   * @param mixed $type
   * @param mixed $run_desc
   * @return mixed
   */
-  public function get_run($run_id, $type, &$run_desc) 
-  {
-    $run_id = $this->db->escape($run_id);
-    $query = "SELECT * FROM `details` WHERE `id` = '$run_id'";
-    $resultSet = $this->db->query($query);
-    $data = $this->db->getNextAssoc($resultSet);
-
-    // can't find specified data
-    if (empty($data)) {
-        return array(null, null);
-    }
-
-    //The Performance data is compressed lightly to avoid max row length
-	if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
-		$contents = unserialize(gzuncompress($data['perfdata']));
-	} else {
-		$contents = json_decode(gzuncompress($data['perfdata']), true);
-	}
-    
-    //This data isnt' needed for display purposes, there's no point in keeping it in this array
-    unset($data['perfdata']);
-
-
-    // The same function is called twice when diff'ing runs. In this case we'll populate the global scope with an array
-    if (is_null($this->run_details))
+    public function get_run($run_id, $type, &$run_desc)
     {
-        $this->run_details = $data;
-    }else
-    {
-        $this->run_details[0] = $this->run_details; 
-        $this->run_details[1] = $data;
+        $run_id = $this->db->escape($run_id);
+        $query = "SELECT * FROM `details` WHERE `id` = '$run_id'";
+        $resultSet = $this->db->query($query);
+        $data = $this->db->getNextAssoc($resultSet);
+
+        // can't find specified data
+        if (empty($data)) {
+            return array(null, null);
+        }
+
+        //The Performance data is compressed lightly to avoid max row length
+        if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
+            $contents = unserialize(gzuncompress($data['perfdata']));
+        } else {
+            $contents = json_decode(gzuncompress($data['perfdata']), true);
+        }
+    
+        //This data isnt' needed for display purposes, there's no point in keeping it in this array
+        unset($data['perfdata']);
+
+
+        // The same function is called twice when diff'ing runs. In this case we'll populate the global scope with an array
+        if (is_null($this->run_details)) {
+            $this->run_details = $data;
+        } else {
+            $this->run_details[0] = $this->run_details;
+            $this->run_details[1] = $data;
+        }
+    
+        $run_desc = "XHProf Run (Namespace=$type)";
+        $this->getRunComparativeData($data['url'], $data['c_url']);
+    
+        return array($contents, $data);
     }
-    
-    $run_desc = "XHProf Run (Namespace=$type)";
-    $this->getRunComparativeData($data['url'], $data['c_url']);
-    
-    return array($contents, $data);
-  }
   
   /**
   * Get stats (pmu, ct, wt) on a url or c_url
-  * 
-  * @param array $data An associative array containing the limit you'd like to set for the queyr, as well as either c_url or url for the desired element. 
+  *
+  * @param array $data An associative array containing the limit you'd like to set for the queyr, as well as either c_url or url for the desired element.
   * @return resource result set from the database query
   */
-  public function getUrlStats($data)
-  {
-      $data['select'] = '`id`, '.$this->db->unixTimestamp('timestamp').' as `timestamp`, `pmu`, `wt`, `cpu`';
-      $rs = $this->getRuns($data);
-      return $rs;
-  }
+    public function getUrlStats($data)
+    {
+        $data['select'] = '`id`, '.$this->db->unixTimestamp('timestamp').' as `timestamp`, `pmu`, `wt`, `cpu`';
+        $rs = $this->getRuns($data);
+        return $rs;
+    }
   
   /**
   * Get comparative information for a given URL and c_url, this information will be used to display stats like how many calls a URL has,
-  * average, min, max execution time, etc. This information is pushed into the global namespace, which is horribly hacky. 
-  * 
+  * average, min, max execution time, etc. This information is pushed into the global namespace, which is horribly hacky.
+  *
   * @param string $url
   * @param string $c_url
   * @return array
   */
-  public function getRunComparativeData($url, $c_url)
-  {
-      $url = $this->db->escape($url);
-      $c_url = $this->db->escape($c_url);
-      //Runs same URL
-      //  count, avg/min/max for wt, cpu, pmu
-      $query = "SELECT count(`id`), avg(`wt`), min(`wt`), max(`wt`),  avg(`cpu`), min(`cpu`), max(`cpu`), avg(`pmu`), min(`pmu`), max(`pmu`) FROM `details` WHERE `url` = '$url'";
-      $rs = $this->db->query($query);
-      $row = $this->db->getNextAssoc($rs);
-      $row['url'] = $url;
+    public function getRunComparativeData($url, $c_url)
+    {
+        $url = $this->db->escape($url);
+        $c_url = $this->db->escape($c_url);
+        //Runs same URL
+        //  count, avg/min/max for wt, cpu, pmu
+        $query = "SELECT count(`id`), avg(`wt`), min(`wt`), max(`wt`),  avg(`cpu`), min(`cpu`), max(`cpu`), avg(`pmu`), min(`pmu`), max(`pmu`) FROM `details` WHERE `url` = '$url'";
+        $rs = $this->db->query($query);
+        $row = $this->db->getNextAssoc($rs);
+        $row['url'] = $url;
       
-      $row['95(`wt`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'wt', 'type' => 'url', 'url' => $url));
-      $row['95(`cpu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'cpu', 'type' => 'url', 'url' => $url));
-      $row['95(`pmu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'pmu', 'type' => 'url', 'url' => $url));
+        $row['95(`wt`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'wt', 'type' => 'url', 'url' => $url));
+        $row['95(`cpu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'cpu', 'type' => 'url', 'url' => $url));
+        $row['95(`pmu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'pmu', 'type' => 'url', 'url' => $url));
 
-      global $comparative;
-      $comparative['url'] = $row;
-      unset($row);
+        global $comparative;
+        $comparative['url'] = $row;
+        unset($row);
       
-      //Runs same c_url
-      //  count, avg/min/max for wt, cpu, pmu
-      $query = "SELECT count(`id`), avg(`wt`), min(`wt`), max(`wt`),  avg(`cpu`), min(`cpu`), max(`cpu`), avg(`pmu`), min(`pmu`), max(`pmu`) FROM `details` WHERE `c_url` = '$c_url'";
-      $rs = $this->db->query($query);
-      $row = $this->db->getNextAssoc($rs);
-      $row['url'] = $c_url;
-      $row['95(`wt`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'wt', 'type' => 'c_url', 'url' => $c_url));
-      $row['95(`cpu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'cpu', 'type' => 'c_url', 'url' => $c_url));
-      $row['95(`pmu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'pmu', 'type' => 'c_url', 'url' => $c_url));
+        //Runs same c_url
+        //  count, avg/min/max for wt, cpu, pmu
+        $query = "SELECT count(`id`), avg(`wt`), min(`wt`), max(`wt`),  avg(`cpu`), min(`cpu`), max(`cpu`), avg(`pmu`), min(`pmu`), max(`pmu`) FROM `details` WHERE `c_url` = '$c_url'";
+        $rs = $this->db->query($query);
+        $row = $this->db->getNextAssoc($rs);
+        $row['url'] = $c_url;
+        $row['95(`wt`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'wt', 'type' => 'c_url', 'url' => $c_url));
+        $row['95(`cpu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'cpu', 'type' => 'c_url', 'url' => $c_url));
+        $row['95(`pmu`)'] = $this->calculatePercentile(array('count' => $row['count(`id`)'], 'column' => 'pmu', 'type' => 'c_url', 'url' => $c_url));
 
-      $comparative['c_url'] = $row;
-      unset($row);
-      return $comparative;
-  }
+        $comparative['c_url'] = $row;
+        unset($row);
+        return $comparative;
+    }
   
-  protected function calculatePercentile($details)
-  {
+    protected function calculatePercentile($details)
+    {
                   $limit = (int) ($details['count'] / 20);
                   $query = "SELECT `{$details['column']}` as `value` FROM `details` WHERE `{$details['type']}` = '{$details['url']}' ORDER BY `{$details['column']}` DESC LIMIT $limit, 1";
                   $rs = $this->db->query($query);
                   $row = $this->db->getNextAssoc($rs);
                   return $row['value'];
-  }
+    }
   
   /**
-  * Save the run in the database. 
-  * 
+  * Save the run in the database.
+  *
   * @param string $xhprof_data
   * @param mixed $type
   * @param string $run_id
   * @param mixed $xhprof_details
   * @return string
   */
-    public function save_run($xhprof_data, $type, $run_id = null, $xhprof_details = null) 
+    public function save_run($xhprof_data, $type, $run_id = null, $xhprof_details = null)
     {
         global $_xhprof;
 
-		$sql = array();
+        $sql = array();
         if ($run_id === null) {
-          $run_id = $this->gen_run_id($type);
+            $run_id = $this->gen_run_id($type);
         }
         
-		/*
+        /*
 		Session data is ommitted purposefully, mostly because it's not likely that the data
 		that resides in $_SESSION at this point is the same as the data that the application
 		started off with (for most apps, it's likely that session data is manipulated on most
@@ -403,73 +389,65 @@ CREATE TABLE `details` (
 		
 		*/
 
-		if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
-			$sql['get'] = $this->db->escape(serialize($_GET));
-			$sql['cookie'] = $this->db->escape(serialize($_COOKIE));
+        if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
+            $sql['get'] = $this->db->escape(serialize($_GET));
+            $sql['cookie'] = $this->db->escape(serialize($_COOKIE));
         
-	        //This code has not been tested
-		    if (isset($_xhprof['savepost']) && $_xhprof['savepost'])
-			{
-				$sql['post'] = $this->db->escape(serialize($_POST));
-			} else {
-				$sql['post'] = $this->db->escape(serialize(array("Skipped" => "Post data omitted by rule")));
-			}
-		} else {
-			$sql['get'] = $this->db->escape(json_encode($_GET));
-			$sql['cookie'] = $this->db->escape(json_encode($_COOKIE));
+            //This code has not been tested
+            if (isset($_xhprof['savepost']) && $_xhprof['savepost']) {
+                $sql['post'] = $this->db->escape(serialize($_POST));
+            } else {
+                $sql['post'] = $this->db->escape(serialize(array("Skipped" => "Post data omitted by rule")));
+            }
+        } else {
+            $sql['get'] = $this->db->escape(json_encode($_GET));
+            $sql['cookie'] = $this->db->escape(json_encode($_COOKIE));
         
-	        //This code has not been tested
-		    if (isset($_xhprof['savepost']) && $_xhprof['savepost'])
-			{
-				$sql['post'] = $this->db->escape(json_encode($_POST));
-			} else {
-				$sql['post'] = $this->db->escape(json_encode(array("Skipped" => "Post data omitted by rule")));
-			}
-		}
+            //This code has not been tested
+            if (isset($_xhprof['savepost']) && $_xhprof['savepost']) {
+                $sql['post'] = $this->db->escape(json_encode($_POST));
+            } else {
+                $sql['post'] = $this->db->escape(json_encode(array("Skipped" => "Post data omitted by rule")));
+            }
+        }
         
         
-	$sql['pmu'] = isset($xhprof_data['main()']['pmu']) ? $xhprof_data['main()']['pmu'] : 0;
- 	$sql['wt']  = isset($xhprof_data['main()']['wt'])  ? $xhprof_data['main()']['wt']  : 0;
-	$sql['cpu'] = isset($xhprof_data['main()']['cpu']) ? $xhprof_data['main()']['cpu'] : 0;        
+        $sql['pmu'] = isset($xhprof_data['main()']['pmu']) ? $xhprof_data['main()']['pmu'] : 0;
+        $sql['wt']  = isset($xhprof_data['main()']['wt'])  ? $xhprof_data['main()']['wt']  : 0;
+        $sql['cpu'] = isset($xhprof_data['main()']['cpu']) ? $xhprof_data['main()']['cpu'] : 0;
 
 
-		// The value of 2 seems to be light enugh that we're not killing the server, but still gives us lots of breathing room on 
-		// full production code. 
-		if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
-			$sql['data'] = $this->db->escape(gzcompress(serialize($xhprof_data), 2));
-		} else {
-			$sql['data'] = $this->db->escape(gzcompress(json_encode($xhprof_data), 2));
-		}
-			
+        // The value of 2 seems to be light enugh that we're not killing the server, but still gives us lots of breathing room on
+        // full production code.
+        if (!isset($GLOBALS['_xhprof']['serializer']) || strtolower($GLOBALS['_xhprof']['serializer'] == 'php')) {
+            $sql['data'] = $this->db->escape(gzcompress(serialize($xhprof_data), 2));
+        } else {
+            $sql['data'] = $this->db->escape(gzcompress(json_encode($xhprof_data), 2));
+        }
+            
         
-	$url   = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : $_SERVER['PHP_SELF'];
- 	$sname = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
-	
+        $url   = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : $_SERVER['PHP_SELF'];
+        $sname = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
+    
         $sql['url'] = $this->db->escape($url);
         $sql['c_url'] = $this->db->escape(_urlSimilartor($_SERVER['REQUEST_URI']));
         $sql['servername'] = $this->db->escape($sname);
         $sql['type']  = (int) (isset($xhprof_details['type']) ? $xhprof_details['type'] : 0);
         $sql['timestamp'] = $this->db->escape($_SERVER['REQUEST_TIME']);
-	$sql['server_id'] = $this->db->escape($_xhprof['servername']);
+        $sql['server_id'] = $this->db->escape($_xhprof['servername']);
         $sql['aggregateCalls_include'] = getenv('xhprof_aggregateCalls_include') ? getenv('xhprof_aggregateCalls_include') : '';
         
         $query = "INSERT INTO `details` (`id`, `url`, `c_url`, `timestamp`, `server name`, `perfdata`, `type`, `cookie`, `post`, `get`, `pmu`, `wt`, `cpu`, `server_id`, `aggregateCalls_include`) VALUES('$run_id', '{$sql['url']}', '{$sql['c_url']}', FROM_UNIXTIME('{$sql['timestamp']}'), '{$sql['servername']}', '{$sql['data']}', '{$sql['type']}', '{$sql['cookie']}', '{$sql['post']}', '{$sql['get']}', '{$sql['pmu']}', '{$sql['wt']}', '{$sql['cpu']}', '{$sql['server_id']}', '{$sql['aggregateCalls_include']}')";
         
         $this->db->query($query);
-        if ($this->db->affectedRows($this->db->linkID) == 1)
-        {
+        if ($this->db->affectedRows($this->db->linkID) == 1) {
             return $run_id;
-        }else
-        {
+        } else {
             global $_xhprof;
-            if ($_xhprof['display'] === true)
-            {
+            if ($_xhprof['display'] === true) {
                 echo "Failed to insert: $query <br>\n";
             }
             return -1;
         }
-  }
-  
-  
-
+    }
 }


### PR DESCRIPTION
Ran phpcbf (php code sniffer fixer) over the codebase with the PSR-2 standard enabled. Added composer.json and php_codesniffer to the require-dev section.

No functionality was changed, except in `index.php`.

For `index.php`, a `die` message was added when config.php could not be found. Some include_once and include statements were changed to require_once, since those files are required for xhprof ui to work.

A few double quoted strings were changed to single quotes.