### PR TITLE
Tideways renamed their free extension; support it.

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -12,7 +12,11 @@ function getExtensionName()
     if (extension_loaded('tideways'))
     {
         return 'tideways';
-    }elseif(extension_loaded('xhprof')) {
+    }elseif(extension_loaded('tideways_xhprof'))
+    {
+        return 'tideways_xhprof';
+    }elseif(extension_loaded('xhprof'))
+    {
         return 'xhprof';
     }
     return false;


### PR DESCRIPTION
Tideways [renamed](https://tideways.com/profiler/blog/releasing-new-tideways-xhprof-extension) their open-source extension. This patch supports adds support for the new name.