### PR TITLE
Allow defining custom locations for xhprof_lib and config.php

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -1,11 +1,13 @@
 <?php
+
+require_once dirname(dirname(__FILE__)) . '/xhprof_lib/defaults.php';
+require_once XHPROF_CONFIG;
+
 if (PHP_SAPI == 'cli') {
   $_SERVER['REMOTE_ADDR'] = null;
   $_SERVER['HTTP_HOST'] = null;
   $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'];
 }
-
-include(dirname(__FILE__) . '/../xhprof_lib/config.php');
 
 function getExtensionName()
 {

--- a/xhprof_html/callgraph.php
+++ b/xhprof_html/callgraph.php
@@ -28,17 +28,13 @@
  *
  * @author Changhao Jiang (cjiang@facebook.com)
  */
-require_once ("../xhprof_lib/config.php");
+
+require_once dirname(dirname(__FILE__)) . '/xhprof_lib/defaults.php';
+require_once XHPROF_CONFIG;
 
 if (false !== $controlIPs && !in_array($_SERVER['REMOTE_ADDR'], $controlIPs))
 {
   die("You do not have permission to view this page.");
-}
-
-// by default assume that xhprof_html & xhprof_lib directories
-// are at the same level.
-if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
 }
 
 include_once XHPROF_LIB_ROOT . '/display/xhprof.php';

--- a/xhprof_html/index.php
+++ b/xhprof_html/index.php
@@ -1,8 +1,8 @@
 <?php
-if (!defined('XHPROF_LIB_ROOT')) {
-  define('XHPROF_LIB_ROOT', dirname(dirname(__FILE__)) . '/xhprof_lib');
-}
-require_once (XHPROF_LIB_ROOT . "/config.php");
+
+require_once dirname(dirname(__FILE__)) . '/xhprof_lib/defaults.php';
+require_once XHPROF_CONFIG;
+
 include_once XHPROF_LIB_ROOT . '/display/xhprof.php';
 include (XHPROF_LIB_ROOT . "/utils/common.php");
 

--- a/xhprof_lib/defaults.php
+++ b/xhprof_lib/defaults.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!defined('XHPROF_LIB_ROOT')) {
+  define('XHPROF_LIB_ROOT', dirname(__FILE__));
+}
+
+if (!defined('XHPROF_CONFIG')) {
+  define('XHPROF_CONFIG', XHPROF_LIB_ROOT . '/config.php');
+}


### PR DESCRIPTION
The current code requires that config.php be located under the repository tree in a fixed location. We would like to manage it in another location.

Additionally, fix callgraph.php to load config.php from a custom xhprof_lib location.